### PR TITLE
Remove Law of Demeter violation with verbose output

### DIFF
--- a/src/main/java/net/boyechko/pdf/autoa11y/CliProcessingListener.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/CliProcessingListener.java
@@ -51,7 +51,8 @@ public class CliProcessingListener implements ProcessingListener {
         formatter.printSummary(detected, resolved, remaining);
     }
 
-    public PrintStream getOutputStream() {
-        return formatter.getStream();
+    @Override
+    public void onVerboseOutput(String message) {
+        formatter.getStream().print(message);
     }
 }

--- a/src/main/java/net/boyechko/pdf/autoa11y/GuiProcessingListener.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/GuiProcessingListener.java
@@ -48,4 +48,9 @@ public class GuiProcessingListener implements ProcessingListener {
     public void onSummary(int detected, int resolved, int remaining) {
         formatter.printSummary(detected, resolved, remaining);
     }
+
+    @Override
+    public void onVerboseOutput(String message) {
+        formatter.getStream().print(message);
+    }
 }

--- a/src/main/java/net/boyechko/pdf/autoa11y/ProcessingListener.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ProcessingListener.java
@@ -27,4 +27,6 @@ public interface ProcessingListener {
     void onIssueFixed(String resolutionNote);
 
     void onSummary(int detected, int resolved, int remaining);
+
+    default void onVerboseOutput(String message) {}
 }

--- a/src/main/java/net/boyechko/pdf/autoa11y/ProcessingService.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ProcessingService.java
@@ -19,9 +19,9 @@ package net.boyechko.pdf.autoa11y;
 
 import com.itextpdf.kernel.pdf.*;
 import com.itextpdf.kernel.pdf.tagging.PdfStructTreeRoot;
-import java.io.PrintStream;
 import java.nio.file.*;
 import java.util.List;
+import java.util.function.Consumer;
 import net.boyechko.pdf.autoa11y.rules.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -246,12 +246,8 @@ public class ProcessingService {
         return issueList;
     }
 
-    private PrintStream getVerboseOutput() {
-        return verbosity.isAtLeast(VerbosityLevel.VERBOSE)
-                ? listener instanceof CliProcessingListener
-                        ? ((CliProcessingListener) listener).getOutputStream()
-                        : null
-                : null;
+    private Consumer<String> getVerboseOutput() {
+        return verbosity.isAtLeast(VerbosityLevel.VERBOSE) ? listener::onVerboseOutput : null;
     }
 
     private IssueList detectAndReportRuleIssues() {


### PR DESCRIPTION
Replace getVerboseOutputStream() with onVerboseOutput(String) callback. ProcessingService no longer reaches through ProcessingListener to get internal PrintStream. TagValidator now accepts Consumer<String> instead of PrintStream, improving encapsulation.

This also fixes GUI verbose output which wasn't working before.