### PR TITLE
Correctly map CL options to log levels

### DIFF
--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/cli/PdfAutoA11yCLI.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/cli/PdfAutoA11yCLI.java
@@ -143,11 +143,14 @@ public class PdfAutoA11yCLI {
     }
 
     private static void configureLogging(VerbosityLevel verbosity) {
-        if (verbosity.isAtLeast(VerbosityLevel.DEBUG)) {
-            System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "debug");
-        } else {
-            System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
-        }
+        String level =
+                switch (verbosity) {
+                    case QUIET -> "error";
+                    case NORMAL -> "warn";
+                    case VERBOSE -> "info";
+                    case DEBUG -> "debug";
+                };
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", level);
     }
 
     private static Logger logger() {

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,5 +1,5 @@
 # Default log level
-org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.defaultLogLevel=warn
 
 # Show timestamps
 org.slf4j.simpleLogger.showDateTime=true


### PR DESCRIPTION
Fixes the problem where WARN and INFO log messages would show up even without `-v` or `-vv` CLI arguments.