### PR TITLE
Add re-mapping of broken ligatures

### DIFF
--- a/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingDefaults.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingDefaults.java
@@ -19,6 +19,7 @@ package net.boyechko.pdf.autoa11y.core;
 
 import java.util.List;
 import java.util.function.Supplier;
+import net.boyechko.pdf.autoa11y.rules.BadlyMappedLigatureRule;
 import net.boyechko.pdf.autoa11y.rules.LanguageSetRule;
 import net.boyechko.pdf.autoa11y.rules.MissingDocumentRule;
 import net.boyechko.pdf.autoa11y.rules.StructureTreeRule;
@@ -43,7 +44,8 @@ public final class ProcessingDefaults {
                 new StructureTreeRule(),
                 new TaggedPdfRule(),
                 new MissingDocumentRule(),
-                new UnmarkedLinkRule());
+                new UnmarkedLinkRule(),
+                new BadlyMappedLigatureRule());
     }
 
     public static List<Supplier<StructureTreeVisitor>> visitorSuppliers() {

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/RemapLigatures.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/RemapLigatures.java
@@ -1,0 +1,330 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2025 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.fixes;
+
+import com.itextpdf.io.font.cmap.CMapLocationFromBytes;
+import com.itextpdf.io.font.cmap.CMapParser;
+import com.itextpdf.io.font.cmap.CMapToUnicode;
+import com.itextpdf.kernel.font.PdfFont;
+import com.itextpdf.kernel.font.PdfFontFactory;
+import com.itextpdf.kernel.font.PdfType0Font;
+import com.itextpdf.kernel.pdf.PdfDictionary;
+import com.itextpdf.kernel.pdf.PdfName;
+import com.itextpdf.kernel.pdf.PdfObject;
+import com.itextpdf.kernel.pdf.PdfStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import net.boyechko.pdf.autoa11y.document.DocumentContext;
+import net.boyechko.pdf.autoa11y.issues.IssueFix;
+
+/** Repairs broken ligature mappings in a font's ToUnicode CMap. */
+public class RemapLigatures implements IssueFix {
+    private static final int P_LIGATURE_REMAP = 20;
+    private static final int BATCH_SIZE = 100;
+
+    private static final Map<Integer, String> LIGATURE_CODEPOINT_EXPANSIONS =
+            Map.of(
+                    0xFB00, "ff",
+                    0xFB01, "fi",
+                    0xFB02, "fl",
+                    0xFB03, "ffi",
+                    0xFB04, "ffl",
+                    0xFB05, "st",
+                    0xFB06, "st");
+
+    // Empirical Arial subset CIDs seen in production PDFs.
+    private static final Map<Integer, String> ARIAL_CID_EXPANSIONS =
+            Map.of(
+                    0x00BF, "fi",
+                    0x1087, "ff",
+                    0x108B, "st");
+
+    private final int fontObjNum;
+    private final String fontName;
+    private final Map<Integer, String> replacementByCode;
+
+    public RemapLigatures(int fontObjNum, String fontName, Map<Integer, String> replacementByCode) {
+        this.fontObjNum = fontObjNum;
+        this.fontName = fontName;
+        this.replacementByCode = Map.copyOf(replacementByCode);
+    }
+
+    @Override
+    public int priority() {
+        return P_LIGATURE_REMAP;
+    }
+
+    @Override
+    public void apply(DocumentContext ctx) throws Exception {
+        PdfObject fontObj = ctx.doc().getPdfObject(fontObjNum);
+        if (!(fontObj instanceof PdfDictionary fontDict)) {
+            return;
+        }
+
+        PdfStream toUnicodeStream = fontDict.getAsStream(PdfName.ToUnicode);
+        if (toUnicodeStream == null) {
+            return;
+        }
+
+        CMapToUnicode cMap = parseToUnicode(toUnicodeStream);
+        Map<Integer, char[]> mappings = extractMappings(cMap);
+
+        boolean changed = false;
+        for (Map.Entry<Integer, String> entry : replacementByCode.entrySet()) {
+            int code = entry.getKey();
+            char[] current = mappings.get(code);
+            if (current == null) {
+                continue;
+            }
+            String currentText = new String(current);
+            String replacement = entry.getValue();
+            if (!replacement.equals(currentText)) {
+                mappings.put(code, replacement.toCharArray());
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            return;
+        }
+
+        PdfType0Font type0Font = loadType0Font(fontDict);
+        byte[] updated = buildToUnicodeCMapBytes(mappings, cMap.getCodeSpaceRanges(), type0Font);
+        toUnicodeStream.setData(updated);
+    }
+
+    public static Map<Integer, String> findBrokenMappings(PdfDictionary fontDict) {
+        PdfStream toUnicode = fontDict.getAsStream(PdfName.ToUnicode);
+        if (toUnicode == null) {
+            return Map.of();
+        }
+
+        CMapToUnicode cmap;
+        try {
+            cmap = parseToUnicode(toUnicode);
+        } catch (Exception e) {
+            return Map.of();
+        }
+
+        boolean arialLike = isArialLike(fontDict);
+        Map<Integer, String> corrections = new LinkedHashMap<>();
+        for (Integer code : cmap.getCodes()) {
+            char[] mappedChars = cmap.lookup(code);
+            if (mappedChars == null || mappedChars.length == 0) {
+                continue;
+            }
+
+            String current = new String(mappedChars);
+            String replacement = null;
+            if (mappedChars.length == 1) {
+                replacement = LIGATURE_CODEPOINT_EXPANSIONS.get((int) mappedChars[0]);
+                if (replacement == null && arialLike) {
+                    String arialReplacement = ARIAL_CID_EXPANSIONS.get(code);
+                    if (arialReplacement != null && arialReplacement.charAt(0) == mappedChars[0]) {
+                        replacement = arialReplacement;
+                    }
+                }
+            }
+
+            if (replacement != null && !replacement.equals(current)) {
+                corrections.put(code, replacement);
+            }
+        }
+        return corrections;
+    }
+
+    public static String fontName(PdfDictionary fontDict) {
+        PdfName baseFont = fontDict.getAsName(PdfName.BaseFont);
+        return baseFont != null ? baseFont.getValue() : "unknown";
+    }
+
+    private static boolean isArialLike(PdfDictionary fontDict) {
+        String name = fontName(fontDict);
+        return name.toLowerCase(Locale.ROOT).contains("arial");
+    }
+
+    private static CMapToUnicode parseToUnicode(PdfStream toUnicodeStream) throws Exception {
+        CMapToUnicode cMap = new CMapToUnicode();
+        CMapParser.parseCid(
+                "ToUnicode", cMap, new CMapLocationFromBytes(toUnicodeStream.getBytes()));
+        return cMap;
+    }
+
+    private static Map<Integer, char[]> extractMappings(CMapToUnicode cMap) {
+        Map<Integer, char[]> mappings = new TreeMap<>();
+        for (Integer code : cMap.getCodes()) {
+            char[] mapped = cMap.lookup(code);
+            if (mapped != null) {
+                mappings.put(code, mapped.clone());
+            }
+        }
+        return mappings;
+    }
+
+    private static PdfType0Font loadType0Font(PdfDictionary fontDict) {
+        try {
+            PdfFont font = PdfFontFactory.createFont(fontDict);
+            if (font instanceof PdfType0Font type0) {
+                return type0;
+            }
+        } catch (Exception ignored) {
+            // Fallback path below does not require a loaded font program.
+        }
+        return null;
+    }
+
+    private static byte[] buildToUnicodeCMapBytes(
+            Map<Integer, char[]> mappings, List<byte[]> codeSpaceRanges, PdfType0Font type0Font) {
+        List<byte[]> ranges = normalizedCodeSpaceRanges(codeSpaceRanges, mappings.keySet());
+        int defaultCodeWidth = ranges.get(0).length;
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("/CIDInit /ProcSet findresource begin\n");
+        builder.append("12 dict begin\n");
+        builder.append("begincmap\n");
+        builder.append(
+                "/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n");
+        builder.append("/CMapName /Adobe-Identity-UCS def\n");
+        builder.append("/CMapType 2 def\n");
+        builder.append(ranges.size() / 2).append(" begincodespacerange\n");
+        for (int i = 0; i + 1 < ranges.size(); i += 2) {
+            builder.append("<")
+                    .append(toHex(ranges.get(i)))
+                    .append("> <")
+                    .append(toHex(ranges.get(i + 1)))
+                    .append(">\n");
+        }
+        builder.append("endcodespacerange\n");
+
+        List<Map.Entry<Integer, char[]>> entries = new ArrayList<>(mappings.entrySet());
+        for (int start = 0; start < entries.size(); start += BATCH_SIZE) {
+            int end = Math.min(entries.size(), start + BATCH_SIZE);
+            builder.append(end - start).append(" beginbfchar\n");
+            for (int i = start; i < end; i++) {
+                Map.Entry<Integer, char[]> entry = entries.get(i);
+                byte[] sourceCodeBytes =
+                        sourceCodeBytes(entry.getKey(), type0Font, defaultCodeWidth);
+                builder.append("<")
+                        .append(toHex(sourceCodeBytes))
+                        .append("> <")
+                        .append(toUtf16Hex(entry.getValue()))
+                        .append(">\n");
+            }
+            builder.append("endbfchar\n");
+        }
+
+        builder.append("endcmap\n");
+        builder.append("CMapName currentdict /CMap defineresource pop\n");
+        builder.append("end\n");
+        builder.append("end\n");
+        return builder.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    private static List<byte[]> normalizedCodeSpaceRanges(
+            List<byte[]> originalRanges, Set<Integer> sourceCodes) {
+        if (originalRanges != null
+                && originalRanges.size() >= 2
+                && originalRanges.size() % 2 == 0) {
+            return originalRanges;
+        }
+
+        int width = 1;
+        for (Integer code : sourceCodes) {
+            if (code != null && code > 0xFF) {
+                width = 2;
+                break;
+            }
+        }
+        byte[] low = new byte[width];
+        byte[] high = new byte[width];
+        for (int i = 0; i < high.length; i++) {
+            high[i] = (byte) 0xFF;
+        }
+        return List.of(low, high);
+    }
+
+    private static byte[] sourceCodeBytes(
+            int sourceCode, PdfType0Font type0Font, int defaultWidth) {
+        if (type0Font != null) {
+            try {
+                return type0Font.getCmap().getCmapBytes(sourceCode);
+            } catch (Exception ignored) {
+                // Fallback below.
+            }
+        }
+
+        byte[] bytes = new byte[defaultWidth];
+        int value = sourceCode;
+        for (int i = defaultWidth - 1; i >= 0; i--) {
+            bytes[i] = (byte) (value & 0xFF);
+            value >>>= 8;
+        }
+        return bytes;
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder out = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            out.append(String.format(Locale.ROOT, "%02X", b & 0xFF));
+        }
+        return out.toString();
+    }
+
+    private static String toUtf16Hex(char[] chars) {
+        StringBuilder out = new StringBuilder(chars.length * 4);
+        for (char c : chars) {
+            out.append(String.format(Locale.ROOT, "%04X", (int) c));
+        }
+        return out.toString();
+    }
+
+    @Override
+    public String describe() {
+        return "Remapped ligatures in font obj #" + fontObjNum;
+    }
+
+    @Override
+    public String describe(DocumentContext ctx) {
+        return "Remapped "
+                + replacementByCode.size()
+                + " ligature mapping(s) in font "
+                + fontName
+                + " (obj #"
+                + fontObjNum
+                + ")";
+    }
+
+    @Override
+    public boolean invalidates(IssueFix otherFix) {
+        if (otherFix instanceof RemapLigatures other) {
+            return this.fontObjNum == other.fontObjNum;
+        }
+        return false;
+    }
+
+    @Override
+    public String groupLabel() {
+        return "ligature mappings corrected";
+    }
+}

--- a/src/main/java/net/boyechko/pdf/autoa11y/issues/IssueType.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issues/IssueType.java
@@ -24,6 +24,7 @@ public enum IssueType {
     NOT_TAGGED_PDF("PDF not tagged"),
     NO_STRUCT_TREE("structure tree missing"),
     TAB_ORDER_NOT_SET("tab order not set"),
+    LIGATURE_MAPPING_BROKEN("fonts with broken ligature mappings"),
 
     // Tag Issues
     TAG_UNKNOWN_ROLE("tags with unknown roles"),

--- a/src/main/java/net/boyechko/pdf/autoa11y/rules/BadlyMappedLigatureRule.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/rules/BadlyMappedLigatureRule.java
@@ -1,0 +1,121 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2025 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.rules;
+
+import com.itextpdf.kernel.pdf.PdfDictionary;
+import com.itextpdf.kernel.pdf.PdfName;
+import com.itextpdf.kernel.pdf.PdfPage;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.boyechko.pdf.autoa11y.document.DocumentContext;
+import net.boyechko.pdf.autoa11y.fixes.RemapLigatures;
+import net.boyechko.pdf.autoa11y.issues.Issue;
+import net.boyechko.pdf.autoa11y.issues.IssueList;
+import net.boyechko.pdf.autoa11y.issues.IssueLocation;
+import net.boyechko.pdf.autoa11y.issues.IssueSeverity;
+import net.boyechko.pdf.autoa11y.issues.IssueType;
+import net.boyechko.pdf.autoa11y.validation.Rule;
+
+/** Detects fonts whose ToUnicode CMaps map ligatures to truncated text. */
+public class BadlyMappedLigatureRule implements Rule {
+
+    @Override
+    public String name() {
+        return "Badly Mapped Ligature Rule";
+    }
+
+    @Override
+    public String passedMessage() {
+        return "No broken ligature mappings found in fonts";
+    }
+
+    @Override
+    public String failedMessage() {
+        return "Some fonts contain broken ligature mappings";
+    }
+
+    @Override
+    public IssueList findIssues(DocumentContext ctx) {
+        IssueList issues = new IssueList();
+
+        Map<Integer, Integer> firstPageByFontObjNum = new LinkedHashMap<>();
+        Map<Integer, PdfDictionary> fontsByObjNum = new LinkedHashMap<>();
+        collectType0Fonts(ctx, fontsByObjNum, firstPageByFontObjNum);
+
+        for (Map.Entry<Integer, PdfDictionary> entry : fontsByObjNum.entrySet()) {
+            int fontObjNum = entry.getKey();
+            PdfDictionary fontDict = entry.getValue();
+            Map<Integer, String> replacements = RemapLigatures.findBrokenMappings(fontDict);
+            if (replacements.isEmpty()) {
+                continue;
+            }
+
+            int firstPage = firstPageByFontObjNum.getOrDefault(fontObjNum, 0);
+            String fontName = RemapLigatures.fontName(fontDict);
+            String message =
+                    "Font "
+                            + fontName
+                            + " has "
+                            + replacements.size()
+                            + " broken ligature mapping(s)";
+            Issue issue =
+                    new Issue(
+                            IssueType.LIGATURE_MAPPING_BROKEN,
+                            IssueSeverity.WARNING,
+                            new IssueLocation(
+                                    firstPage > 0 ? firstPage : null, "font obj #" + fontObjNum),
+                            message,
+                            new RemapLigatures(fontObjNum, fontName, replacements));
+            issues.add(issue);
+        }
+
+        return issues;
+    }
+
+    private void collectType0Fonts(
+            DocumentContext ctx,
+            Map<Integer, PdfDictionary> fontsByObjNum,
+            Map<Integer, Integer> firstPageByFontObjNum) {
+        for (int pageNum = 1; pageNum <= ctx.doc().getNumberOfPages(); pageNum++) {
+            PdfPage page = ctx.doc().getPage(pageNum);
+            PdfDictionary fontResource = page.getResources().getResource(PdfName.Font);
+            if (fontResource == null) {
+                continue;
+            }
+
+            for (PdfName fontResourceName : fontResource.keySet()) {
+                PdfDictionary fontDict = fontResource.getAsDictionary(fontResourceName);
+                if (fontDict == null) {
+                    continue;
+                }
+                if (!PdfName.Type0.equals(fontDict.getAsName(PdfName.Subtype))) {
+                    continue;
+                }
+                if (fontDict.getAsStream(PdfName.ToUnicode) == null) {
+                    continue;
+                }
+                if (fontDict.getIndirectReference() == null) {
+                    continue;
+                }
+                int objNum = fontDict.getIndirectReference().getObjNumber();
+                fontsByObjNum.putIfAbsent(objNum, fontDict);
+                firstPageByFontObjNum.putIfAbsent(objNum, pageNum);
+            }
+        }
+    }
+}

--- a/src/test/java/net/boyechko/pdf/autoa11y/rules/BadlyMappedLigatureRuleTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/rules/BadlyMappedLigatureRuleTest.java
@@ -1,0 +1,127 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2025 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.rules;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfReader;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+import net.boyechko.pdf.autoa11y.PdfTestBase;
+import net.boyechko.pdf.autoa11y.document.Content;
+import net.boyechko.pdf.autoa11y.document.DocumentContext;
+import net.boyechko.pdf.autoa11y.issues.Issue;
+import net.boyechko.pdf.autoa11y.issues.IssueList;
+import net.boyechko.pdf.autoa11y.issues.IssueType;
+import org.junit.jupiter.api.Test;
+
+class BadlyMappedLigatureRuleTest extends PdfTestBase {
+
+    @Test
+    void detectsBrokenLigatureMappingsInCatalogSample() throws Exception {
+        Path inputPath = Path.of("src/test/resources/catalog_p1.pdf");
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfReader(inputPath.toString()))) {
+            BadlyMappedLigatureRule rule = new BadlyMappedLigatureRule();
+            IssueList issues = rule.findIssues(new DocumentContext(pdfDoc));
+
+            assertFalse(issues.isEmpty(), "Should detect broken ligature mappings");
+            Issue issue = issues.get(0);
+            assertEquals(IssueType.LIGATURE_MAPPING_BROKEN, issue.type());
+            assertNotNull(issue.fix(), "Should provide automatic ligature remapping fix");
+        }
+    }
+
+    @Test
+    void remapsLigaturesSoExtractedWordsAreCorrect() throws Exception {
+        Path inputPath = Path.of("src/test/resources/catalog_p1.pdf");
+        Path outputPath = testOutputPath("catalog_p1-ligatures-fixed.pdf");
+
+        try (PdfDocument pdfDoc =
+                new PdfDocument(
+                        new PdfReader(inputPath.toString()),
+                        new PdfWriter(outputPath.toString()))) {
+            BadlyMappedLigatureRule rule = new BadlyMappedLigatureRule();
+            DocumentContext ctx = new DocumentContext(pdfDoc);
+            IssueList issues = rule.findIssues(ctx);
+            assertFalse(issues.isEmpty(), "Expected at least one ligature-mapping issue");
+
+            for (Issue issue : issues) {
+                assertNotNull(issue.fix(), "Issue should be fixable");
+                issue.fix().apply(ctx);
+            }
+
+            String pageText = pageText(pdfDoc, 1);
+            assertTrue(pageText.contains("offers"), "offers should be fully extracted");
+            assertTrue(pageText.contains("certificates"), "certificates should be fully extracted");
+            assertTrue(pageText.contains("students"), "students should be fully extracted");
+            assertTrue(
+                    pageText.contains("postbaccalaureate"),
+                    "postbaccalaureate should be fully extracted");
+            assertTrue(pageText.contains("study"), "study should be fully extracted");
+            assertTrue(pageText.contains("just"), "just should be fully extracted");
+            assertTrue(pageText.contains("standards"), "standards should be fully extracted");
+
+            assertFalse(pageText.contains("ofers"), "Broken offer text should be fixed");
+            assertFalse(
+                    pageText.contains("certifcates"), "Broken certificate text should be fixed");
+            assertFalse(pageText.contains("sudents"), "Broken student text should be fixed");
+            assertFalse(
+                    pageText.contains("posbaccalaureate"),
+                    "Broken postbaccalaureate text should be fixed");
+            assertFalse(pageText.contains("sudy"), "Broken study text should be fixed");
+            assertFalse(pageText.contains("jus "), "Broken just text should be fixed");
+            assertFalse(pageText.contains("sandards"), "Broken standards text should be fixed");
+        }
+    }
+
+    @Test
+    void noIssueForSimpleTaggedPdf() throws Exception {
+        Path testPdf =
+                createTestPdf(
+                        (pdfDoc, layoutDoc) -> {
+                            layoutDoc.add(
+                                    new com.itextpdf.layout.element.Paragraph(
+                                            "Simple text without ligature mapping problems."));
+                        });
+
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfReader(testPdf.toString()))) {
+            BadlyMappedLigatureRule rule = new BadlyMappedLigatureRule();
+            IssueList issues = rule.findIssues(new DocumentContext(pdfDoc));
+            assertTrue(
+                    issues.isEmpty(), "Simple test PDF should not trigger ligature mapping rule");
+        }
+    }
+
+    private static String pageText(PdfDocument pdfDoc, int pageNum) {
+        Map<Integer, String> byMcid = Content.extractTextForPage(pdfDoc.getPage(pageNum));
+        StringBuilder joined = new StringBuilder();
+        for (String segment : new TreeMap<>(byMcid).values()) {
+            if (segment == null || segment.isBlank()) {
+                continue;
+            }
+            if (joined.length() > 0) {
+                joined.append(' ');
+            }
+            joined.append(segment);
+        }
+        return joined.toString();
+    }
+}


### PR DESCRIPTION
- Added new document issue type LIGATURE_MAPPING_BROKEN
- Added rule BadlyMappedLigatureRule, which scans page font resources for Type0 fonts with /ToUnicode, and detects broken ligature mappings and emits fixable issues per font object.
* Added fix RemapLigatures, which parses /ToUnicode CMap, applies replacements, rewrites CMap stream. Supports standard ligature Unicode expansion (FB00..FB06) and the broken Arial CID cases seen in your sample (0x108B->st, 0x1087->ff, 0x00BF->fi).
* Added regression tests in BadlyMappedLigatureRuleTest