### PR TITLE
feat/flag missing alt text

### DIFF
--- a/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingDefaults.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingDefaults.java
@@ -36,6 +36,7 @@ import net.boyechko.pdf.autoa11y.visitors.BulletGlyphVisitor;
 import net.boyechko.pdf.autoa11y.visitors.EmptyElementVisitor;
 import net.boyechko.pdf.autoa11y.visitors.EmptyLinkTagVisitor;
 import net.boyechko.pdf.autoa11y.visitors.FigureWithTextVisitor;
+import net.boyechko.pdf.autoa11y.visitors.MissingAltTextVisitor;
 import net.boyechko.pdf.autoa11y.visitors.MistaggedArtifactVisitor;
 import net.boyechko.pdf.autoa11y.visitors.NeedlessNestingVisitor;
 import net.boyechko.pdf.autoa11y.visitors.ParagraphOfLinksVisitor;
@@ -64,6 +65,7 @@ public final class ProcessingDefaults {
                 NeedlessNestingVisitor::new,
                 MistaggedArtifactVisitor::new,
                 FigureWithTextVisitor::new,
+                MissingAltTextVisitor::new,
                 EmptyLinkTagVisitor::new,
                 BulletGlyphVisitor::new,
                 SchemaValidationVisitor::new,

--- a/src/main/java/net/boyechko/pdf/autoa11y/issues/IssueType.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issues/IssueType.java
@@ -37,6 +37,7 @@ public enum IssueType {
     TAG_WRONG_CHILD_COUNT("tags with wrong child count"),
     TAG_WRONG_CHILD_PATTERN("tags with wrong child pattern"),
     FIGURE_WITH_TEXT("figures containing text"),
+    FIGURE_MISSING_ALT("figures without alt text"),
     EMPTY_LINK_TAG("empty link tags"),
 
     // Structure Issues

--- a/src/main/java/net/boyechko/pdf/autoa11y/visitors/MissingAltTextVisitor.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/visitors/MissingAltTextVisitor.java
@@ -1,0 +1,126 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2025 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.visitors;
+
+import com.itextpdf.kernel.geom.Rectangle;
+import com.itextpdf.kernel.pdf.PdfDictionary;
+import com.itextpdf.kernel.pdf.PdfName;
+import com.itextpdf.kernel.pdf.tagging.PdfMcr;
+import com.itextpdf.kernel.pdf.tagging.PdfObjRef;
+import java.util.Map;
+import java.util.Set;
+import net.boyechko.pdf.autoa11y.document.Content;
+import net.boyechko.pdf.autoa11y.document.StructureTree;
+import net.boyechko.pdf.autoa11y.issues.Issue;
+import net.boyechko.pdf.autoa11y.issues.IssueList;
+import net.boyechko.pdf.autoa11y.issues.IssueLocation;
+import net.boyechko.pdf.autoa11y.issues.IssueSeverity;
+import net.boyechko.pdf.autoa11y.issues.IssueType;
+import net.boyechko.pdf.autoa11y.validation.StructureTreeVisitor;
+import net.boyechko.pdf.autoa11y.validation.VisitorContext;
+
+/**
+ * Reports meaningful Figure elements that lack alt text. These are content images large enough to
+ * convey information but without descriptions for screen readers. No automatic fix — these need
+ * human-written alt text.
+ */
+public class MissingAltTextVisitor implements StructureTreeVisitor {
+    private final IssueList issues = new IssueList();
+
+    @Override
+    public String name() {
+        return "Missing Alt Text Visitor";
+    }
+
+    @Override
+    public String description() {
+        return "Content images should have alt text";
+    }
+
+    @Override
+    public boolean enterElement(VisitorContext ctx) {
+        if (!PdfName.Figure.equals(ctx.node().getRole())) {
+            return true;
+        }
+        if (ctx.node().getAlt() != null) {
+            return true;
+        }
+
+        int pageNumber = ctx.getPageNumber();
+        if (pageNumber == 0) {
+            return true;
+        }
+
+        if (!hasImageMcr(ctx, pageNumber)) {
+            return true;
+        }
+
+        Rectangle bounds = Content.getBoundsForElement(ctx.node(), ctx.docCtx(), pageNumber);
+        if (bounds == null || !MistaggedArtifactVisitor.isMeaningfulSize(bounds)) {
+            return true;
+        }
+
+        Issue issue =
+                new Issue(
+                        IssueType.FIGURE_MISSING_ALT,
+                        IssueSeverity.WARNING,
+                        new IssueLocation(ctx.node()),
+                        "Figure without alt text (needs manual description)");
+        issues.add(issue);
+        return true;
+    }
+
+    @Override
+    public IssueList getIssues() {
+        return issues;
+    }
+
+    private boolean hasImageMcr(VisitorContext ctx, int pageNumber) {
+        for (PdfMcr mcr : StructureTree.collectMcrs(ctx.node())) {
+            if (mcr instanceof PdfObjRef) {
+                continue;
+            }
+            int mcid = mcr.getMcid();
+            if (mcid < 0) {
+                continue;
+            }
+
+            PdfDictionary pageDict = mcr.getPageObject();
+            if (pageDict == null) {
+                continue;
+            }
+            int pageNum = ctx.doc().getPageNumber(pageDict);
+            if (pageNum <= 0) {
+                continue;
+            }
+
+            Map<Integer, Set<Content.ContentKind>> contentKinds =
+                    ctx.docCtx()
+                            .getOrComputeContentKinds(
+                                    pageNum,
+                                    () ->
+                                            Content.extractContentKindsForPage(
+                                                    ctx.doc().getPage(pageNum)));
+            Set<Content.ContentKind> kinds = contentKinds.get(mcid);
+            if (kinds != null && kinds.contains(Content.ContentKind.IMAGE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/net/boyechko/pdf/autoa11y/visitors/MissingAltTextVisitorTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/visitors/MissingAltTextVisitorTest.java
@@ -1,0 +1,133 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2025 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.visitors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.itextpdf.io.image.ImageData;
+import com.itextpdf.io.image.ImageDataFactory;
+import com.itextpdf.kernel.pdf.PdfDictionary;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfName;
+import com.itextpdf.kernel.pdf.PdfNumber;
+import com.itextpdf.kernel.pdf.PdfReader;
+import com.itextpdf.kernel.pdf.PdfString;
+import com.itextpdf.kernel.pdf.canvas.PdfCanvas;
+import com.itextpdf.kernel.pdf.tagging.PdfMcrNumber;
+import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import java.nio.file.Path;
+import java.util.Base64;
+import net.boyechko.pdf.autoa11y.PdfTestBase;
+import net.boyechko.pdf.autoa11y.document.DocumentContext;
+import net.boyechko.pdf.autoa11y.issues.IssueList;
+import net.boyechko.pdf.autoa11y.issues.IssueType;
+import net.boyechko.pdf.autoa11y.validation.StructureTreeWalker;
+import net.boyechko.pdf.autoa11y.validation.TagSchema;
+import org.junit.jupiter.api.Test;
+
+class MissingAltTextVisitorTest extends PdfTestBase {
+    private static final String ONE_PIXEL_PNG_BASE64 =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0s0AAAAASUVORK5CYII=";
+
+    @Test
+    void detectsLargeFigureWithoutAltText() throws Exception {
+        Path pdfFile = createTaggedImagePdf("large-no-alt.pdf", 200f, null);
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfReader(pdfFile.toString()))) {
+            StructureTreeWalker walker = new StructureTreeWalker(TagSchema.loadDefault());
+            walker.addVisitor(new MissingAltTextVisitor());
+
+            IssueList issues = walker.walk(pdfDoc.getStructTreeRoot(), new DocumentContext(pdfDoc));
+            assertEquals(1, issues.size(), "Large figure without alt text should be detected");
+            assertEquals(IssueType.FIGURE_MISSING_ALT, issues.get(0).type());
+            assertNull(issues.get(0).fix(), "Should have no automatic fix");
+        }
+    }
+
+    @Test
+    void doesNotFlagSmallFigure() throws Exception {
+        Path pdfFile = createTaggedImagePdf("small-no-alt.pdf", 48f, null);
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfReader(pdfFile.toString()))) {
+            StructureTreeWalker walker = new StructureTreeWalker(TagSchema.loadDefault());
+            walker.addVisitor(new MissingAltTextVisitor());
+
+            IssueList issues = walker.walk(pdfDoc.getStructTreeRoot(), new DocumentContext(pdfDoc));
+            assertTrue(
+                    issues.isEmpty(),
+                    "Small figure should not be flagged (handled by MistaggedArtifactVisitor)");
+        }
+    }
+
+    @Test
+    void doesNotFlagFigureWithAltText() throws Exception {
+        Path pdfFile = createTaggedImagePdf("large-with-alt.pdf", 200f, "A photo of a building");
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfReader(pdfFile.toString()))) {
+            StructureTreeWalker walker = new StructureTreeWalker(TagSchema.loadDefault());
+            walker.addVisitor(new MissingAltTextVisitor());
+
+            IssueList issues = walker.walk(pdfDoc.getStructTreeRoot(), new DocumentContext(pdfDoc));
+            assertTrue(issues.isEmpty(), "Figure with alt text should not be flagged");
+        }
+    }
+
+    @Test
+    void doesNotFlagFigureWithOnlyTextMcrs() throws Exception {
+        // A figure with text content but no image MCR — FigureWithTextVisitor's territory
+        Path pdfFile =
+                createTestPdf(
+                        testOutputPath("text-figure.pdf"),
+                        (pdfDoc, layoutDoc) -> {
+                            layoutDoc.add(
+                                    new com.itextpdf.layout.element.Paragraph("Some text content"));
+                        });
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfReader(pdfFile.toString()))) {
+            StructureTreeWalker walker = new StructureTreeWalker(TagSchema.loadDefault());
+            walker.addVisitor(new MissingAltTextVisitor());
+
+            IssueList issues = walker.walk(pdfDoc.getStructTreeRoot(), new DocumentContext(pdfDoc));
+            assertTrue(issues.isEmpty(), "Figure with only text MCRs should not be flagged");
+        }
+    }
+
+    private Path createTaggedImagePdf(String filename, float renderedSize, String altText)
+            throws Exception {
+        return createStructuredTestPdf(
+                testOutputPath(filename),
+                (pdfDoc, firstPage, root, document) -> {
+                    PdfStructElem figure = new PdfStructElem(pdfDoc, PdfName.Figure, firstPage);
+                    if (altText != null) {
+                        figure.setAlt(new PdfString(altText));
+                    }
+                    document.addKid(figure);
+
+                    PdfMcrNumber mcr = new PdfMcrNumber(firstPage, figure);
+                    figure.addKid(mcr);
+
+                    PdfDictionary props = new PdfDictionary();
+                    props.put(PdfName.MCID, new PdfNumber(mcr.getMcid()));
+
+                    ImageData imageData =
+                            ImageDataFactory.create(
+                                    Base64.getDecoder().decode(ONE_PIXEL_PNG_BASE64));
+                    PdfCanvas canvas = new PdfCanvas(firstPage);
+                    canvas.beginMarkedContent(PdfName.Figure, props);
+                    canvas.addImageWithTransformationMatrix(
+                            imageData, renderedSize, 0, 0, renderedSize, 100, 650, false);
+                    canvas.endMarkedContent();
+                });
+    }
+}


### PR DESCRIPTION
- **fix(rules): Remove hard-coded X from LanguageSetRule's messages**
- **tests: Add tests for StructureTreeExistsRule**
- **fix(core/ProcessingDefaults): StructureTreeExistsRule goes earlier**
- **fix(core/ProcessingService): Don't over-report fatal issues**
- **feat(ui/ProcessingReporter): printLine() wraps at word boundaries**
- **feat(core,issues,rules): Add PdfUaConformanceRule**
- **fix(document/PdfCustodian): Stop automatically adding PDF/UA-1 flag**
- **tests(PdfUaConformanceRule): Test iTextPDF's internals we access**
- **feat(document/DocumentContext): Add getOrComputeContentKinds()**
- **style(document/Content): Clean up comments**
- **feat(visitors/MistaggedArtifactV): Flag all decorative images**
- **feat(visitors): Add MissingAltTextVisitor**
