### PR TITLE
fix/schema validation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Versioning](https://semver.org/).
   silently failing on documents with a /RoleMap. Fix factories compared raw
   element roles instead of mapped roles, so they never matched standard names
   like `L` or `LBody` when the PDF used custom role names.
+- Fixed multi-child schema fixes (e.g., WrapPairsOfLblLBodyInLI) leaving
+  sibling issues unresolved. The multi-fix was applied correctly but only
+  the first issue was marked resolved; remaining siblings now share the
+  same fix reference and are resolved via invalidation.
 - Fixed `--only-checks` ignoring sidecar check replacements (e.g.,
   `artifact-patterns`). The `only` filter was not consulting the `skip` set,
   causing both the default and sidecar-injected check to run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Versioning](https://semver.org/).
   `--include-checks=MisartifactedTextCheck`.
 
 ### Fixed
+- Fixed schema fixes (WrapInLI, WrapInLBody, ExtractLBodyToList, and others)
+  silently failing on documents with a /RoleMap. Fix factories compared raw
+  element roles instead of mapped roles, so they never matched standard names
+  like `L` or `LBody` when the PDF used custom role names.
 - Fixed `--only-checks` ignoring sidecar check replacements (e.g.,
   `artifact-patterns`). The `only` filter was not consulting the `skip` set,
   causing both the default and sidecar-injected check to run.

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/SchemaValidationCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/SchemaValidationCheck.java
@@ -149,12 +149,20 @@ public class SchemaValidationCheck extends StructTreeCheck {
         if (rule == null || rule.getAllowedChildren() == null) return;
         if (rule.getAllowedChildren().isEmpty()) return;
 
-        boolean multiFixCreated = false;
+        IssueFix multiFix = null;
 
         for (int i = 0; i < ctx.childRoles().size(); i++) {
             String childRole = ctx.childRoles().get(i);
             if (!rule.getAllowedChildren().contains(childRole)) {
-                IssueFix fix = createChildFix(ctx, i, multiFixCreated, childRole);
+                IssueFix fix;
+                if (multiFix != null) {
+                    fix = multiFix;
+                } else {
+                    fix = createChildFix(ctx, i, childRole);
+                    if (fix instanceof SchemaChildrenFix) {
+                        multiFix = fix;
+                    }
+                }
 
                 String message =
                         formatRole(childRole) + " not allowed under " + formatRole(ctx.role());
@@ -165,10 +173,6 @@ public class SchemaValidationCheck extends StructTreeCheck {
                                 locAtElem(ctx, ctx.children().get(i)),
                                 message,
                                 fix));
-
-                if (fix instanceof SchemaChildrenFix) {
-                    multiFixCreated = true;
-                }
             }
         }
     }
@@ -194,16 +198,7 @@ public class SchemaValidationCheck extends StructTreeCheck {
         }
     }
 
-    private IssueFix createChildFix(
-            StructTreeContext ctx, int childIndex, boolean multiFixCreated, String childRole) {
-        if (multiFixCreated) {
-            logger.debug(
-                    "Fix already created for parent {}; no further fix for kid {}",
-                    formatRole(ctx.role()),
-                    formatRole(childRole));
-            return null;
-        }
-
+    private IssueFix createChildFix(StructTreeContext ctx, int childIndex, String childRole) {
         PdfStructElem childNode = ctx.children().get(childIndex);
 
         IssueFix multi = SchemaValidationFix.createForChildren(ctx.node(), ctx.children());

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/StaleScribbleCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/StaleScribbleCheck.java
@@ -21,6 +21,7 @@ import static net.boyechko.pdf.autoa11y.document.StructTree.SCRIBBLE_PREFIX;
 
 import com.itextpdf.kernel.pdf.PdfName;
 import com.itextpdf.kernel.pdf.PdfString;
+import net.boyechko.pdf.autoa11y.fixes.StaleScribbleFix;
 import net.boyechko.pdf.autoa11y.issue.Issue;
 import net.boyechko.pdf.autoa11y.issue.IssueList;
 import net.boyechko.pdf.autoa11y.issue.IssueSev;
@@ -59,7 +60,8 @@ public class StaleScribbleCheck extends StructTreeCheck {
                             IssueType.STALE_SCRIBBLE,
                             IssueSev.WARNING,
                             locAtElem(ctx),
-                            "Stale workflow scribble: " + value));
+                            "Stale workflow scribble: " + value,
+                            new StaleScribbleFix(ctx.node(), value)));
         }
         return true;
     }

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/StructTree.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/StructTree.java
@@ -380,8 +380,12 @@ public final class StructTree {
      * Returns the mapped role for a structure element, or the raw role if no mapping is available.
      */
     public static String mappedRole(PdfStructElem n) {
-        PdfDictionary roleMap = pdfDocumentFor(n).getStructTreeRoot().getRoleMap();
         PdfName role = n.getRole();
+        PdfStructTreeRoot structTreeRoot = pdfDocumentFor(n).getStructTreeRoot();
+        if (structTreeRoot == null) {
+            return role.getValue();
+        }
+        PdfDictionary roleMap = structTreeRoot.getRoleMap();
 
         if (roleMap != null) {
             PdfName mappedRole = roleMap.getAsName(role);

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/SchemaValidationFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/SchemaValidationFix.java
@@ -21,6 +21,7 @@ import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
 import java.util.List;
 import java.util.Objects;
 import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.document.StructTree;
 import net.boyechko.pdf.autoa11y.fixes.schema.*;
 import net.boyechko.pdf.autoa11y.issue.IssueFix;
 import net.boyechko.pdf.autoa11y.issue.IssueLoc;
@@ -84,7 +85,7 @@ public abstract class SchemaValidationFix implements IssueFix {
     }
 
     public String getParentRole() {
-        return parent.getRole().getValue();
+        return StructTree.mappedRole(parent);
     }
 
     @Override

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/StaleScribbleFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/StaleScribbleFix.java
@@ -1,0 +1,63 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2026 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.fixes;
+
+import com.itextpdf.kernel.pdf.PdfName;
+import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.document.Format;
+import net.boyechko.pdf.autoa11y.issue.IssueFix;
+import net.boyechko.pdf.autoa11y.issue.IssueLoc;
+
+/** Clears the /T key from a structure element that contains a stale workflow scribble. */
+public class StaleScribbleFix implements IssueFix {
+    private static final int P_CLEAR_SCRIBBLE = 50;
+
+    private final PdfStructElem element;
+    private final String scribble;
+
+    public StaleScribbleFix(PdfStructElem element, String scribble) {
+        this.element = element;
+        this.scribble = scribble;
+    }
+
+    @Override
+    public int priority() {
+        return P_CLEAR_SCRIBBLE;
+    }
+
+    @Override
+    public void apply(DocContext ctx) {
+        element.getPdfObject().remove(PdfName.T);
+    }
+
+    @Override
+    public String describe() {
+        return "Cleared stale scribble: " + scribble;
+    }
+
+    @Override
+    public String describe(DocContext ctx) {
+        return describe() + Format.loc(IssueLoc.atElem(ctx, element));
+    }
+
+    @Override
+    public String groupLabel() {
+        return "Stale scribble cleanup";
+    }
+}

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/ChangePToLblInLI.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/ChangePToLblInLI.java
@@ -21,6 +21,7 @@ import com.itextpdf.kernel.pdf.PdfName;
 import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
 import java.util.List;
 import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.document.StructTree;
 import net.boyechko.pdf.autoa11y.issue.IssueFix;
 
 /** Changes a P element to a Lbl in an LI structure. */
@@ -30,11 +31,11 @@ public final class ChangePToLblInLI extends SchemaChildrenFix {
     }
 
     public static IssueFix tryCreate(PdfStructElem parent, List<PdfStructElem> kids) {
-        String parentRole = parent.getRole().getValue();
+        String parentRole = StructTree.mappedRole(parent);
         // There should be exactly two kids, one of which is LBody and the other P
         if ("LI".equals(parentRole) && kids.size() == 2) {
-            String kid1Role = kids.get(0).getRole().getValue();
-            String kid2Role = kids.get(1).getRole().getValue();
+            String kid1Role = StructTree.mappedRole(kids.get(0));
+            String kid2Role = StructTree.mappedRole(kids.get(1));
 
             if (("P".equals(kid1Role) && "LBody".equals(kid2Role))
                     || ("LBody".equals(kid1Role) && "P".equals(kid2Role))) {
@@ -47,7 +48,7 @@ public final class ChangePToLblInLI extends SchemaChildrenFix {
     @Override
     public void apply(DocContext ctx) throws Exception {
         for (PdfStructElem p : kids) {
-            if ("P".equals(p.getRole().getValue())) {
+            if ("P".equals(StructTree.mappedRole(p))) {
                 p.setRole(PdfName.Lbl);
             }
         }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/ExtractLBodyToList.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/ExtractLBodyToList.java
@@ -44,8 +44,8 @@ public final class ExtractLBodyToList extends SchemaChildFix {
     }
 
     public static IssueFix tryCreate(PdfStructElem kid, PdfStructElem parent) {
-        String kidRole = kid.getRole().getValue();
-        String parentRole = parent.getRole().getValue();
+        String kidRole = StructTree.mappedRole(kid);
+        String parentRole = StructTree.mappedRole(parent);
         if ("LBody".equals(kidRole) && !"LI".equals(parentRole) && !"L".equals(parentRole)) {
             return new ExtractLBodyToList(kid, parent);
         }
@@ -81,7 +81,7 @@ public final class ExtractLBodyToList extends SchemaChildFix {
         if (listIndex < containerKids.size()) {
             IStructureNode nextSibling = containerKids.get(listIndex);
             if (nextSibling instanceof PdfStructElem nextElem
-                    && "L".equals(nextElem.getRole().getValue())) {
+                    && "L".equals(StructTree.mappedRole(nextElem))) {
                 listElem = nextElem;
             }
         }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/SchemaChildFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/SchemaChildFix.java
@@ -18,6 +18,7 @@
 package net.boyechko.pdf.autoa11y.fixes.schema;
 
 import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import net.boyechko.pdf.autoa11y.document.StructTree;
 import net.boyechko.pdf.autoa11y.fixes.SchemaValidationFix;
 
 /** Schema fix that operates on a single child element. */
@@ -45,6 +46,6 @@ public abstract class SchemaChildFix extends SchemaValidationFix {
     }
 
     public String getKidRole() {
-        return kid.getRole().getValue();
+        return StructTree.mappedRole(kid);
     }
 }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/SchemaChildrenFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/SchemaChildrenFix.java
@@ -52,6 +52,7 @@ public abstract class SchemaChildrenFix extends SchemaValidationFix {
 
     @Override
     public boolean invalidates(IssueFix otherFix) {
+        if (this == otherFix) return true;
         if (otherFix instanceof SchemaChildFix singleFix) {
             return getParentRole().equals(singleFix.getParentRole())
                     && singleFix.getParent().equals(parent)

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/TreatLblFigureAsBullet.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/TreatLblFigureAsBullet.java
@@ -21,6 +21,7 @@ import com.itextpdf.kernel.pdf.PdfName;
 import com.itextpdf.kernel.pdf.PdfString;
 import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
 import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.document.StructTree;
 import net.boyechko.pdf.autoa11y.issue.IssueFix;
 
 /** Fixes a Lbl[Figure] structure by converting the Figure to a bullet label. */
@@ -30,8 +31,8 @@ public final class TreatLblFigureAsBullet extends SchemaChildFix {
     }
 
     public static IssueFix tryCreate(PdfStructElem kid, PdfStructElem parent) {
-        String kidRole = kid.getRole().getValue();
-        String parentRole = parent.getRole().getValue();
+        String kidRole = StructTree.mappedRole(kid);
+        String parentRole = StructTree.mappedRole(parent);
         if ("Lbl".equals(parentRole) && "Figure".equals(kidRole)) {
             return new TreatLblFigureAsBullet(kid, parent);
         }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/WrapInLBody.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/WrapInLBody.java
@@ -21,6 +21,7 @@ import com.itextpdf.kernel.pdf.PdfName;
 import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
 import java.util.List;
 import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.document.StructTree;
 import net.boyechko.pdf.autoa11y.issue.IssueFix;
 
 /** Wraps a single child element under LI in a LBody structure. */
@@ -32,8 +33,8 @@ public final class WrapInLBody extends SchemaChildFix {
     }
 
     public static IssueFix tryCreate(PdfStructElem kid, PdfStructElem parent) {
-        String kidRole = kid.getRole().getValue();
-        String parentRole = parent.getRole().getValue();
+        String kidRole = StructTree.mappedRole(kid);
+        String parentRole = StructTree.mappedRole(parent);
         if ("LI".equals(parentRole) && validKidRoles.contains(kidRole)) {
             return new WrapInLBody(kid, parent);
         }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/WrapInLI.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/WrapInLI.java
@@ -21,6 +21,7 @@ import com.itextpdf.kernel.pdf.PdfName;
 import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
 import java.util.List;
 import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.document.StructTree;
 import net.boyechko.pdf.autoa11y.issue.IssueFix;
 
 /** Wraps a single child element in an LI structure. */
@@ -34,8 +35,8 @@ public final class WrapInLI extends SchemaChildFix {
     }
 
     public static IssueFix tryCreate(PdfStructElem kid, PdfStructElem parent) {
-        String kidRole = kid.getRole().getValue();
-        String parentRole = parent.getRole().getValue();
+        String kidRole = StructTree.mappedRole(kid);
+        String parentRole = StructTree.mappedRole(parent);
         if ("L".equals(parentRole) && validKidRoles.contains(kidRole)) {
             return new WrapInLI(kid, parent);
         }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/WrapPairsOfLblLBodyInLI.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/WrapPairsOfLblLBodyInLI.java
@@ -31,14 +31,14 @@ public final class WrapPairsOfLblLBodyInLI extends SchemaChildrenFix {
     }
 
     public static IssueFix tryCreate(PdfStructElem parent, List<PdfStructElem> kids) {
-        String parentRole = parent.getRole().getValue();
+        String parentRole = StructTree.mappedRole(parent);
 
         // Check if parent is L and we have alternating Lbl/LBody pattern
         if ("L".equals(parentRole) && kids.size() >= 2 && kids.size() % 2 == 0) {
             // Verify alternating Lbl/LBody pattern
             for (int i = 0; i < kids.size(); i += 2) {
-                String lblRole = kids.get(i).getRole().getValue();
-                String lBodyRole = kids.get(i + 1).getRole().getValue();
+                String lblRole = StructTree.mappedRole(kids.get(i));
+                String lBodyRole = StructTree.mappedRole(kids.get(i + 1));
 
                 if (!"Lbl".equals(lblRole) || !"LBody".equals(lBodyRole)) {
                     return null;

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/WrapPairsOfLblPInLI.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/schema/WrapPairsOfLblPInLI.java
@@ -31,14 +31,14 @@ public final class WrapPairsOfLblPInLI extends SchemaChildrenFix {
     }
 
     public static IssueFix tryCreate(PdfStructElem parent, List<PdfStructElem> kids) {
-        String parentRole = parent.getRole().getValue();
+        String parentRole = StructTree.mappedRole(parent);
 
         // Check if parent is L and we have alternating Lbl/P pattern
         if ("L".equals(parentRole) && kids.size() >= 2 && kids.size() % 2 == 0) {
             // Verify alternating Lbl/P pattern
             for (int i = 0; i < kids.size(); i += 2) {
-                String lblRole = kids.get(i).getRole().getValue();
-                String pRole = kids.get(i + 1).getRole().getValue();
+                String lblRole = StructTree.mappedRole(kids.get(i));
+                String pRole = StructTree.mappedRole(kids.get(i + 1));
 
                 if (!"Lbl".equals(lblRole) || !"P".equals(pRole)) {
                     return null;

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/StaleScribbleCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/StaleScribbleCheckTest.java
@@ -50,7 +50,7 @@ class StaleScribbleCheckTest extends PdfTestBase {
 
             assertEquals(1, issues.size());
             assertEquals(IssueType.STALE_SCRIBBLE, issues.get(0).type());
-            assertNull(issues.get(0).fix(), "Stale scribbles have no automatic fix");
+            assertNotNull(issues.get(0).fix(), "Stale scribbles should have an automatic fix");
         }
     }
 

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/StaleScribbleFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/StaleScribbleFixTest.java
@@ -1,0 +1,88 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2026 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.fixes;
+
+import static net.boyechko.pdf.autoa11y.document.StructTree.SCRIBBLE_PREFIX;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfName;
+import com.itextpdf.kernel.pdf.PdfString;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import com.itextpdf.kernel.pdf.tagging.PdfStructTreeRoot;
+import net.boyechko.pdf.autoa11y.PdfTestBase;
+import net.boyechko.pdf.autoa11y.document.DocContext;
+import org.junit.jupiter.api.Test;
+
+class StaleScribbleFixTest extends PdfTestBase {
+
+    @Test
+    void removesTitleWithScribblePrefix() throws Exception {
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            PdfStructTreeRoot root = new PdfStructTreeRoot(pdfDoc);
+            PdfStructElem document = new PdfStructElem(pdfDoc, new PdfName("Document"));
+            root.addKid(document);
+
+            PdfStructElem h1 = new PdfStructElem(pdfDoc, PdfName.H1);
+            h1.getPdfObject().put(PdfName.T, new PdfString(SCRIBBLE_PREFIX + "NeedsReview"));
+            document.addKid(h1);
+
+            DocContext ctx = new DocContext(pdfDoc);
+            new StaleScribbleFix(h1, SCRIBBLE_PREFIX + "NeedsReview").apply(ctx);
+
+            assertNull(h1.getPdfObject().getAsString(PdfName.T));
+        }
+    }
+
+    @Test
+    void idempotentWhenTitleAlreadyAbsent() throws Exception {
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            PdfStructTreeRoot root = new PdfStructTreeRoot(pdfDoc);
+            PdfStructElem document = new PdfStructElem(pdfDoc, new PdfName("Document"));
+            root.addKid(document);
+
+            PdfStructElem p = new PdfStructElem(pdfDoc, PdfName.P);
+            document.addKid(p);
+
+            DocContext ctx = new DocContext(pdfDoc);
+            assertDoesNotThrow(() -> new StaleScribbleFix(p, "__gone").apply(ctx));
+            assertNull(p.getPdfObject().getAsString(PdfName.T));
+        }
+    }
+
+    @Test
+    void preservesOtherDictionaryEntries() throws Exception {
+        try (PdfDocument pdfDoc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            PdfStructTreeRoot root = new PdfStructTreeRoot(pdfDoc);
+            PdfStructElem document = new PdfStructElem(pdfDoc, new PdfName("Document"));
+            root.addKid(document);
+
+            PdfStructElem h1 = new PdfStructElem(pdfDoc, PdfName.H1);
+            h1.getPdfObject().put(PdfName.T, new PdfString(SCRIBBLE_PREFIX + "OK"));
+            h1.getPdfObject().put(PdfName.Lang, new PdfString("en"));
+            document.addKid(h1);
+
+            DocContext ctx = new DocContext(pdfDoc);
+            new StaleScribbleFix(h1, SCRIBBLE_PREFIX + "OK").apply(ctx);
+
+            assertNull(h1.getPdfObject().getAsString(PdfName.T));
+            assertEquals("en", h1.getPdfObject().getAsString(PdfName.Lang).toUnicodeString());
+        }
+    }
+}


### PR DESCRIPTION
- **fix(document/StructTree): mappedRole() handles null StructTreeRoot**
- **fix(fixes/SchemaValidation): Use mapped roles rather than raw ones**
- **fix(checks/SchemaValidation,fixes): Invalidation logic**
- **feat(fixes/StaleScribble): Add a fix to clear /T values**
