### PR TITLE
feat/tree diagram orphaned content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ Thumbs.db
 # Project specific
 inputs/
 outputs/
+.itext-sources/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/).
 ## Unreleased
 
 ### Added
+- Added `OrphanedContentCheck` (and corresponding `OrphanedContentFix`)
+  that detects MCRs and OBJRs whose page reference no longer resolves --
+  typically structure-tree remnants left after pages are deleted in
+  Acrobat without cleaning up the tags. The fix removes the orphan and
+  cascade-prunes any ancestor that becomes empty (stopping at the
+  Document element). Runs early in the structure-tree check phase so
+  downstream tree-walkers see a cleaned tree.
 - Added optional `ReorderWebCapturesCheck` (and corresponding
   `ReorderWebCapturesFix`) that reorders the document's pages to match a
   configured URL order from the sidecar's `ReorderWebCapturesCheck:` key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ Versioning](https://semver.org/).
   is skipped.
 
 ### Fixed
+- `!ARTIFACT` on a `Link` element that has no text MCRs (only a `PdfObjRef`
+  pointing to its annotation) now correctly prunes the empty `Link` after
+  removing the annotation. Previously, `MistaggedArtifactFix` left the `OBJR`
+  in the structure tree and skipped pruning because the MCID map was empty,
+  leaving a structurally empty `Link` element in the output.
 - `--dump-tree` content-kind labels (`text`, `image`, `path`) on MCRs are now
   correct on multi-page PDFs. Previously, the per-page kind maps were merged by
   raw MCID across pages, so an MCID reused on a later page would overwrite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ Versioning](https://semver.org/).
   is skipped.
 
 ### Fixed
+- `--dump-tree` no longer crashes on PDFs with MCRs that have no page
+  reference (e.g. after pages were deleted in Acrobat). Orphaned MCRs are
+  now displayed as `[orphaned mcid N]` instead of crashing with a
+  `NullPointerException` inside iText's `PdfMcr.getPageObject()`.
 - `!ARTIFACT` on a `Link` element that has no text MCRs (only a `PdfObjRef`
   pointing to its annotation) now correctly prunes the empty `Link` after
   removing the annotation. Previously, `MistaggedArtifactFix` left the `OBJR`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ references IssueFix.
 - Tag schema: `src/main/resources/tagschema-PDF-UA1.yaml`
 - Frequent PDF inputs: `inputs/` directory
 - Frequent PDF outputs: `outputs/` directory
+- iText 9.5.0 kernel sources: `.itext-sources/` (gitignored, read with
+  the `Read` tool — no Bash needed)
 
 # Adding New Rules/Fixes
 

--- a/pdf-autoa11y
+++ b/pdf-autoa11y
@@ -32,7 +32,7 @@ if [ ! -d "$CLASSES_DIR" ] || [ ! -f "$CLASSPATH_FILE" ]; then
     fi
 # Recompile if any source file is newer than the last successful compile.
 elif [ -d "$SRC_DIR" ] && \
-     [ -n "$(find "$SRC_DIR" -type f \( -name '*.java' -o -name '*.yaml' \) \
+     [ -n "$(find "$SRC_DIR" -type f \( -name '*.java' -o -name '*.yaml' -o -name '*.xml' -o -name '*.properties' \) \
             -newer "$COMPILE_STAMP" -print -quit 2>/dev/null)" ]; then
     echo "Source files changed since last compile. Recompiling..." >&2
     if ! compile; then

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/BadlyMappedLigatureCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/BadlyMappedLigatureCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/ClearRoleMapCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/ClearRoleMapCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/EmptyElementCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/EmptyElementCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/EmptyLinkTagCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/EmptyLinkTagCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/FigureWithTextCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/FigureWithTextCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/ImageOnlyDocumentCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/ImageOnlyDocumentCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/LanguageSetCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/LanguageSetCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/ListlikeParagraphsCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/ListlikeParagraphsCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/MissingAltTextCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/MissingAltTextCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/MissingDocumentCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/MissingDocumentCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/MissingPagePartsCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/MissingPagePartsCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/MissingPagePartsCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/MissingPagePartsCheck.java
@@ -115,7 +115,7 @@ public class MissingPagePartsCheck extends StructTreeCheck {
 
         for (IStructureNode kid : documentKids) {
             if (kid instanceof PdfStructElem elem && !PdfName.Part.equals(elem.getRole())) {
-                int pageNum = StructTree.determinePageNumber(ctx, elem);
+                int pageNum = StructTree.pageOf(elem, ctx);
                 if (pageNum > 0) {
                     return true;
                 }

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/MistaggedArtifactCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/MistaggedArtifactCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/MistaggedBulletedListCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/MistaggedBulletedListCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/NeedlessNestingCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/NeedlessNestingCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/OrphanedContentCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/OrphanedContentCheck.java
@@ -1,0 +1,81 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2026 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.checks;
+
+import com.itextpdf.kernel.pdf.tagging.IStructureNode;
+import com.itextpdf.kernel.pdf.tagging.PdfMcr;
+import com.itextpdf.kernel.pdf.tagging.PdfObjRef;
+import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import java.util.List;
+import net.boyechko.pdf.autoa11y.fixes.OrphanedContentFix;
+import net.boyechko.pdf.autoa11y.issue.Issue;
+import net.boyechko.pdf.autoa11y.issue.IssueFix;
+import net.boyechko.pdf.autoa11y.issue.IssueList;
+import net.boyechko.pdf.autoa11y.issue.IssueSev;
+import net.boyechko.pdf.autoa11y.issue.IssueType;
+import net.boyechko.pdf.autoa11y.validation.StructTreeCheck;
+import net.boyechko.pdf.autoa11y.validation.StructTreeContext;
+
+/**
+ * Detects MCRs and OBJRs whose page reference no longer resolves -- typically remnants left in the
+ * structure tree after a page is deleted in Acrobat without cleaning up the tags.
+ */
+public class OrphanedContentCheck extends StructTreeCheck {
+
+    private final IssueList issues = new IssueList();
+
+    @Override
+    public String name() {
+        return "Orphaned Content Check";
+    }
+
+    @Override
+    public String description() {
+        return "MCRs and OBJRs should reference content on a valid page";
+    }
+
+    @Override
+    public void leaveElement(StructTreeContext ctx) {
+        PdfStructElem node = ctx.node();
+        List<IStructureNode> kids = node.getKids();
+        if (kids == null) return;
+
+        for (IStructureNode kid : kids) {
+            if (kid instanceof PdfMcr mcr && mcr.getPageIndirectReference() == null) {
+                IssueFix fix = new OrphanedContentFix(node, mcr);
+                Issue issue =
+                        new Issue(
+                                IssueType.ORPHANED_CONTENT,
+                                IssueSev.WARNING,
+                                locAtElem(ctx),
+                                "Orphaned " + typeOf(mcr) + " in " + ctx.role(),
+                                fix);
+                issues.add(issue);
+            }
+        }
+    }
+
+    private static String typeOf(PdfMcr mcr) {
+        return mcr instanceof PdfObjRef ? "OBJR" : "MCID " + mcr.getMcid();
+    }
+
+    @Override
+    public IssueList getIssues() {
+        return issues;
+    }
+}

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/ParagraphOfLinksCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/ParagraphOfLinksCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/PdfUaConformanceCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/PdfUaConformanceCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/ReplaceRoleMapCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/ReplaceRoleMapCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/SchemaValidationCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/SchemaValidationCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/StaleScribbleCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/StaleScribbleCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/StructTreeOrderCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/StructTreeOrderCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/StructureTreeExistsCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/StructureTreeExistsCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/TabOrderCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/TabOrderCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/TaggedPdfCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/TaggedPdfCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/checks/UnexpectedWidgetCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/checks/UnexpectedWidgetCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingDefaults.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingDefaults.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingDefaults.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingDefaults.java
@@ -46,6 +46,7 @@ public final class ProcessingDefaults {
                 TaggedPdfCheck::new,
                 PdfUaConformanceCheck::new,
                 // Structure tree checks
+                OrphanedContentCheck::new,
                 NeedlessNestingCheck::new,
                 MissingPagePartsCheck::new,
                 MistaggedArtifactCheck::new,

--- a/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingListener.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingListener.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingService.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/core/ProcessingService.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/Content.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/Content.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/DocContext.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/DocContext.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/Format.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/Format.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/Geometry.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/Geometry.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/Label.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/Label.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/PdfCustodian.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/PdfCustodian.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/RoleMap.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/RoleMap.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/StructTree.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/StructTree.java
@@ -120,6 +120,8 @@ public final class StructTree {
 
     /** Returns the page number for any MCR or OBJR (since PdfObjRef extends PdfMcr). */
     public static int pageOf(PdfMcr mcr) {
+        // getPageObject() would NPE inside iText when encountering orphaned MCRs.
+        if (mcr.getPageIndirectReference() == null) return 0;
         PdfDictionary pageObj = mcr.getPageObject();
         if (pageObj == null) return 0;
         PdfDocument doc = pageObj.getIndirectReference().getDocument();

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/StructTree.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/StructTree.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/document/StructTree.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/document/StructTree.java
@@ -89,8 +89,8 @@ public final class StructTree {
         return false;
     }
 
-    /** Determines the page number for a structure element, using cache then recursion. */
-    public static int determinePageNumber(DocContext ctx, PdfStructElem elem) {
+    /** Finds the page via /Pg, then context cache, then recursion into kids. */
+    public static int pageOf(PdfStructElem elem, DocContext ctx) {
         PdfDictionary pg = elem.getPdfObject().getAsDictionary(PdfName.Pg);
         if (pg != null) {
             int pageNum = ctx.doc().getPageNumber(pg);
@@ -109,7 +109,7 @@ public final class StructTree {
         if (kids != null) {
             for (IStructureNode kid : kids) {
                 if (kid instanceof PdfStructElem childElem) {
-                    int pageNum = determinePageNumber(ctx, childElem);
+                    int pageNum = pageOf(childElem, ctx);
                     if (pageNum > 0) return pageNum;
                 }
             }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/BadlyMappedLigatureFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/BadlyMappedLigatureFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/ClearRoleMapFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/ClearRoleMapFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/EmptyElementFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/EmptyElementFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/EmptyLinkTagFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/EmptyLinkTagFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/EmptyLinkTagFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/EmptyLinkTagFix.java
@@ -105,7 +105,7 @@ public class EmptyLinkTagFix implements IssueFix {
             return;
         }
 
-        int resolvedPageNum = pageNum > 0 ? pageNum : StructTree.determinePageNumber(ctx, linkElem);
+        int resolvedPageNum = pageNum > 0 ? pageNum : StructTree.pageOf(linkElem, ctx);
         if (resolvedPageNum <= 0 || resolvedPageNum > ctx.doc().getNumberOfPages()) {
             return;
         }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/FigureWithTextFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/FigureWithTextFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/MissingDocumentFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/MissingDocumentFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/MissingPagePartsFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/MissingPagePartsFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/MissingPagePartsFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/MissingPagePartsFix.java
@@ -108,7 +108,7 @@ public class MissingPagePartsFix implements IssueFix {
         }
 
         for (PdfStructElem elem : elementsToMove) {
-            int pageNum = StructTree.determinePageNumber(ctx, elem);
+            int pageNum = StructTree.pageOf(elem, ctx);
             if (pageNum > 0 && pageParts.containsKey(pageNum)) {
                 PdfStructElem targetPart = pageParts.get(pageNum);
                 StructTree.moveKid(elem, documentElem, targetPart);

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/MistaggedArtifactFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/MistaggedArtifactFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/MistaggedArtifactFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/MistaggedArtifactFix.java
@@ -31,6 +31,7 @@ import com.itextpdf.kernel.pdf.PdfResources;
 import com.itextpdf.kernel.pdf.PdfStream;
 import com.itextpdf.kernel.pdf.annot.PdfAnnotation;
 import com.itextpdf.kernel.pdf.canvas.parser.util.PdfCanvasParser;
+import com.itextpdf.kernel.pdf.tagging.IStructureNode;
 import com.itextpdf.kernel.pdf.tagging.PdfMcr;
 import com.itextpdf.kernel.pdf.tagging.PdfObjRef;
 import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
@@ -96,6 +97,8 @@ public class MistaggedArtifactFix implements IssueFix {
         if (!mcidsByPage.isEmpty()) {
             rewriteMcidsAsArtifacts(mcidsByPage);
             removeMcrEntries(mcidsByPage);
+        }
+        if (targetAll || !mcidsByPage.isEmpty()) {
             pruneEmptySubtree(element);
         }
     }
@@ -313,6 +316,10 @@ public class MistaggedArtifactFix implements IssueFix {
                 PdfName subtype = annotDict.getAsName(PdfName.Subtype);
                 if (subtype != null && PdfName.Link.equals(subtype)) {
                     findAndRemoveAnnotation(annotDict, ctx);
+                    IStructureNode parent = objRef.getParent();
+                    if (parent instanceof PdfStructElem parentElem) {
+                        parentElem.removeKid(objRef);
+                    }
                 }
             }
         }

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/NeedlessNestingFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/NeedlessNestingFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/OrphanedContentFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/OrphanedContentFix.java
@@ -1,0 +1,101 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2026 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.fixes;
+
+import com.itextpdf.kernel.pdf.PdfArray;
+import com.itextpdf.kernel.pdf.PdfObject;
+import com.itextpdf.kernel.pdf.tagging.PdfMcr;
+import com.itextpdf.kernel.pdf.tagging.PdfObjRef;
+import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.document.StructTree;
+import net.boyechko.pdf.autoa11y.issue.IssueFix;
+import net.boyechko.pdf.autoa11y.issue.IssueLoc;
+import net.boyechko.pdf.autoa11y.issue.IssueMsg;
+
+/**
+ * Removes a single orphaned MCR/OBJR from its parent, then prunes any ancestor that becomes empty
+ * as a result.
+ */
+public class OrphanedContentFix implements IssueFix {
+    private static final int P_REMOVE_ORPHANED = 25;
+
+    private final PdfStructElem parent;
+    private final PdfMcr orphan;
+    private int prunedCount;
+
+    public OrphanedContentFix(PdfStructElem parent, PdfMcr orphan) {
+        this.parent = parent;
+        this.orphan = orphan;
+    }
+
+    @Override
+    public int priority() {
+        return P_REMOVE_ORPHANED;
+    }
+
+    @Override
+    public void apply(DocContext ctx) {
+        // Locate the orphan in parent's /K so we can remove it by index. We
+        // avoid parent.removeKid(IStructureNode), which routes through
+        // ParentTreeHandler.unregisterMcr -> PdfMcr.getPageObject(), and
+        // getPageObject() NPEs when getPageIndirectReference() is null.
+        // removeKid(index, prepareForReAdding=true) skips the unregister step,
+        // which is safe for orphans since they were never registered in the
+        // ParentTree to begin with.
+        PdfArray kArray = StructTree.normalizeKArray(parent);
+        if (kArray == null) return;
+
+        PdfObject orphanObj = orphan.getPdfObject();
+        int idx = -1;
+        for (int i = 0; i < kArray.size(); i++) {
+            if (StructTree.isSame(kArray.get(i), orphanObj)) {
+                idx = i;
+                break;
+            }
+        }
+        if (idx < 0) return;
+
+        parent.removeKid(idx, true);
+        prunedCount = 1 + StructTree.pruneEmpty(parent);
+    }
+
+    @Override
+    public String describe() {
+        return "Removed orphaned " + typeOf(orphan);
+    }
+
+    @Override
+    public IssueMsg describeLocated(DocContext ctx) {
+        return new IssueMsg(describe(), IssueLoc.atElem(ctx, parent));
+    }
+
+    @Override
+    public String groupLabel() {
+        return "orphaned MCRs/OBJRs removed";
+    }
+
+    @Override
+    public int resolvedItemCount() {
+        return prunedCount;
+    }
+
+    private static String typeOf(PdfMcr mcr) {
+        return mcr instanceof PdfObjRef ? "OBJR" : "MCID " + mcr.getMcid();
+    }
+}

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/ParagraphOfLinksFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/ParagraphOfLinksFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/ReplaceRoleMapFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/ReplaceRoleMapFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/StructTreeOrderFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/StructTreeOrderFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/UnexpectedWidgetFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/UnexpectedWidgetFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/WrapBulletAlignedKidsInLBody.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/WrapBulletAlignedKidsInLBody.java
@@ -171,7 +171,7 @@ public final class WrapBulletAlignedKidsInLBody implements IssueFix {
 
     /** Determines where to insert the new LI based on bullet y-position. */
     private int findInsertPosition(PdfStructElem listElem, DocContext ctx) {
-        int pageNum = StructTree.determinePageNumber(ctx, parent);
+        int pageNum = StructTree.pageOf(parent, ctx);
         List<PdfStructElem> existingLIs = StructTree.childrenOf(listElem, PdfStructElem.class);
 
         for (int i = 0; i < existingLIs.size(); i++) {

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/WrapBulletAlignedKidsInLBody.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/WrapBulletAlignedKidsInLBody.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/fixes/WrapParagraphRunInList.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/fixes/WrapParagraphRunInList.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/Issue.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/Issue.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueFix.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueFix.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueList.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueList.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueLoc.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueLoc.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueLoc.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueLoc.java
@@ -67,7 +67,7 @@ public sealed interface IssueLoc {
         if (ctx == null || element == null) {
             return none();
         }
-        int pageNum = StructTree.determinePageNumber(ctx, element);
+        int pageNum = StructTree.pageOf(element, ctx);
         Integer maybePage = pageNum > 0 ? pageNum : null;
         String role = element.getRole() != null ? element.getRole().getValue() : null;
         return new AtElem(element, maybePage, role, null);

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueMsg.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueMsg.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueSev.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueSev.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueType.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueType.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueType.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/issue/IssueType.java
@@ -50,6 +50,7 @@ public enum IssueType {
     MISARTIFACTED_TEXT("artifact blocks containing text that should be tagged"),
     UNMARKED_LINK("Link annotations not tagged"),
     UNEXPECTED_WIDGET("non-functional Widget annotations"),
+    ORPHANED_CONTENT("orphaned MCRs"),
     EMPTY_ELEMENT("empty structure elements"),
     LIST_TAGGED_AS_PARAGRAPHS("list tagged as a series of paragraphs"),
     BULLET_ALIGNED_KIDS_IN_ELEMENT("bullet-aligned content inside non-list element"),

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/AccessibilityReport.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/AccessibilityReport.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/FormattedListener.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/FormattedListener.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/IssueFormatter.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/IssueFormatter.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/LogIssueFormatter.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/LogIssueFormatter.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/LoggingListener.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/LoggingListener.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/SidecarConfig.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/SidecarConfig.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/StructTreeTablePrinter.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/StructTreeTablePrinter.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/TreeDiagram.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/TreeDiagram.java
@@ -39,9 +39,19 @@ import org.slf4j.LoggerFactory;
 public final class TreeDiagram {
     private static final Logger logger = LoggerFactory.getLogger(TreeDiagram.class);
 
-    /** Matches "Role #objNum" with an optional trailing quoted scribble. */
+    /**
+     * Matches a struct-element line in a tree diagram: optional box-drawing/space prefix, then
+     * "Role #objNum" with an optional trailing quoted scribble. The {@code (?<!<)} lookbehind
+     * prevents matching OBJR lines, where the label appears inside {@code <...>}.
+     */
     private static final Pattern ANNOTATED_LINE =
-            Pattern.compile("^\\s*(\\w+)\\s+#(\\d+)(?:\\s+\"([^\"]*)\")?.*$");
+            Pattern.compile("^\\W*(?<!<)(\\w+)\\s+#(\\d+)(?:\\s+\"([^\"]*)\")?.*$");
+
+    /* Box drawing characters for detailed tree diagram. */
+    public static final String SELF_PREFIX_MIDDLE = "├── ";
+    public static final String SELF_PREFIX_FINAL = "└── ";
+    public static final String LEAF_PREFIX_MIDDLE = "│   ";
+    public static final String LEAF_PREFIX_FINAL = "    ";
 
     private TreeDiagram() {}
 
@@ -136,12 +146,19 @@ public final class TreeDiagram {
         StringBuilder sb = new StringBuilder();
         int[] currentPage = {0};
         if (node instanceof PdfStructElem elem) {
-            appendDetailedTree(sb, elem, 0, mcidInfo, currentPage);
+            appendDetailedTree(sb, elem, "", "", mcidInfo, currentPage);
         } else {
-            for (IStructureNode kid : node.getKids()) {
-                if (kid instanceof PdfStructElem childElem) {
-                    appendDetailedTree(sb, childElem, 0, mcidInfo, currentPage);
-                }
+            List<IStructureNode> kids = node.getKids();
+            for (int i = 0; i < kids.size(); i++) {
+                if (!(kids.get(i) instanceof PdfStructElem childElem)) continue;
+                boolean hasMore = hasStructElemAfter(kids, i);
+                appendDetailedTree(
+                        sb,
+                        childElem,
+                        hasMore ? SELF_PREFIX_MIDDLE : SELF_PREFIX_FINAL,
+                        hasMore ? LEAF_PREFIX_MIDDLE : LEAF_PREFIX_FINAL,
+                        mcidInfo,
+                        currentPage);
             }
         }
         return sb.toString();
@@ -150,29 +167,34 @@ public final class TreeDiagram {
     private static void appendDetailedTree(
             StringBuilder sb,
             PdfStructElem elem,
-            int depth,
+            String selfPrefix,
+            String childrenPrefix,
             Map<Content.PageMcid, Content.McidContent> mcidInfo,
             int[] currentPage) {
-        // Emit page break before the element if its first leaf is on a new page
         emitPageBreakIfNeeded(sb, firstLeafPage(elem), currentPage);
+        sb.append(selfPrefix).append(structElemLabel(elem)).append('\n');
 
-        sb.append(indentation(depth));
-        sb.append(structElemLabel(elem));
-        sb.append('\n');
-
-        // Output all children in /K array order
         List<IStructureNode> kids = elem.getKids();
         if (kids == null) return;
 
-        String childIndent = indentation(depth + 1);
-        for (IStructureNode kid : kids) {
-            switch (kid) {
+        for (int i = 0; i < kids.size(); i++) {
+            boolean hasMore = hasStructElemAfter(kids, i);
+            String leafPrefix = hasMore ? LEAF_PREFIX_MIDDLE : LEAF_PREFIX_FINAL;
+
+            switch (kids.get(i)) {
                 case PdfStructElem childElem -> {
-                    appendDetailedTree(sb, childElem, depth + 1, mcidInfo, currentPage);
+                    String connector = hasMore ? SELF_PREFIX_MIDDLE : SELF_PREFIX_FINAL;
+                    appendDetailedTree(
+                            sb,
+                            childElem,
+                            childrenPrefix + connector,
+                            childrenPrefix + leafPrefix,
+                            mcidInfo,
+                            currentPage);
                 }
                 case PdfObjRef objRef -> {
                     emitPageBreakIfNeeded(sb, pageOf(objRef), currentPage);
-                    sb.append(childIndent);
+                    sb.append(childrenPrefix).append(leafPrefix);
                     sb.append("<").append(objrLabel(objRef)).append(">");
                     DocValue.Destination dest = DocValue.destinationOf(objRef);
                     sb.append(' ').append(dest);
@@ -188,7 +210,7 @@ public final class TreeDiagram {
                     DocValue.Mcr mcrLabel =
                             new DocValue.Mcr(pageMcid.mcid(), mc != null ? mc.kinds() : null);
                     emitPageBreakIfNeeded(sb, pageMcid.pageNum(), currentPage);
-                    sb.append(childIndent);
+                    sb.append(childrenPrefix).append(leafPrefix);
                     sb.append("[").append(mcrLabel).append("]");
                     if (elem.getRole().equals(PdfName.Link)
                             || Set.of(
@@ -204,9 +226,17 @@ public final class TreeDiagram {
                     }
                     sb.append('\n');
                 }
-                default -> throw new IllegalArgumentException("Unexpected value: " + kid);
+                default -> throw new IllegalArgumentException("Unexpected value: " + kids.get(i));
             }
         }
+    }
+
+    /** Returns true if a {@link PdfStructElem} appears after {@code fromIdx} in {@code kids}. */
+    private static boolean hasStructElemAfter(List<IStructureNode> kids, int fromIdx) {
+        for (int j = fromIdx + 1; j < kids.size(); j++) {
+            if (kids.get(j) instanceof PdfStructElem) return true;
+        }
+        return false;
     }
 
     /** Returns the page number of the first MCR or OBJR leaf in a subtree, or 0 if none. */
@@ -253,10 +283,6 @@ public final class TreeDiagram {
             return "unknown";
         }
         return annot.toString();
-    }
-
-    private static String indentation(int depth) {
-        return " ".repeat(2 * depth);
     }
 
     // === Annotate tree from edited dump file =================================

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/TreeDiagram.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/TreeDiagram.java
@@ -285,20 +285,20 @@ public final class TreeDiagram {
         return annot.toString();
     }
 
-    // === Annotate tree from edited dump file =================================
+    // === Annotate tree from tree diagram file =================================
 
-    /** Result of applying annotations from a dump-tree file. */
+    /** Result of applying scribbles from an annotated tree diagram. */
     public record AnnotateResult(
             int updated, int cleared, int unchanged, int unmatchedLines, int unmatchedElements) {}
 
     /**
-     * Parses an edited {@code --dump-tree} output and writes quoted scribbles back to the matching
-     * elements' {@code /T} keys. Lines without a quoted scribble clear {@code /T} on the matched
-     * element. Role mismatches and unknown object numbers are reported via {@code warn}.
+     * Parses an annotated tree diagram and writes quoted scribbles back to the matching elements'
+     * {@code /T} keys. Lines without a quoted scribble clear {@code /T} on the matched element.
+     * Role mismatches and unknown object numbers are reported via {@code warn}.
      */
     public static AnnotateResult annotateFromString(
-            PdfDocument doc, String annotatedDump, Consumer<String> warn) {
-        Map<ElemKey, Optional<String>> desired = parseDump(annotatedDump, warn);
+            PdfDocument doc, String annotatedDiagram, Consumer<String> warn) {
+        Map<ElemKey, Optional<String>> desired = parseDiagram(annotatedDiagram, warn);
 
         Map<Integer, PdfStructElem> byObj = new HashMap<>();
         PdfStructTreeRoot root = doc.getStructTreeRoot();
@@ -354,7 +354,23 @@ public final class TreeDiagram {
         return new AnnotateResult(updated, cleared, unchanged, unmatchedLines, unmatchedElements);
     }
 
-    private static Map<ElemKey, Optional<String>> parseDump(String content, Consumer<String> warn) {
+    /**
+     * Parses an annotated tree diagram into a map of element keys to desired scribble values.
+     *
+     * <p>Each non-blank line is matched against {@link #ANNOTATED_LINE}. Lines that match but carry
+     * no quoted scribble produce {@code Optional.empty()}, signalling that {@code /T} should be
+     * cleared on the matched element. Lines that do not match the pattern are silently skipped.
+     * Duplicate keys with conflicting scribble values are reported via {@code warn}.
+     *
+     * @param content text of an annotated tree diagram, possibly with added quoted scribbles
+     * @param warn callback invoked with a human-readable message when the same element key appears
+     *     more than once with differing scribble values
+     * @return map from each parsed {@link ElemKey} to its desired scribble ({@code
+     *     Optional.empty()} means clear {@code /T}); elements not mentioned in the diagram are
+     *     absent from the map
+     */
+    private static Map<ElemKey, Optional<String>> parseDiagram(
+            String content, Consumer<String> warn) {
         Map<ElemKey, Optional<String>> out = new HashMap<>();
         List<String> lines = content.lines().toList();
         for (int i = 0; i < lines.size(); i++) {
@@ -379,6 +395,9 @@ public final class TreeDiagram {
         return out;
     }
 
+    /**
+     * Recursively indexes all {@link PdfStructElem} nodes in a subtree by indirect object number.
+     */
     private static void indexByObjNum(IStructureNode node, Map<Integer, PdfStructElem> out) {
         if (node instanceof PdfStructElem elem) {
             int objNum = StructTree.objNum(elem);
@@ -392,5 +411,6 @@ public final class TreeDiagram {
         }
     }
 
+    /** Structural element key consisting of its role and indirect reference object number. */
     private record ElemKey(String role, int objNum) {}
 }

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/TreeDiagram.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/TreeDiagram.java
@@ -205,6 +205,12 @@ public final class TreeDiagram {
                     sb.append('\n');
                 }
                 case PdfMcr mcr -> {
+                    if (mcr.getPageIndirectReference() == null) {
+                        sb.append(childrenPrefix).append(leafPrefix);
+                        sb.append("[orphaned mcid ").append(mcr.getMcid()).append("]");
+                        sb.append('\n');
+                        continue;
+                    }
                     Content.PageMcid pageMcid = new Content.PageMcid(pageOf(mcr), mcr.getMcid());
                     Content.McidContent mc = mcidInfo.get(pageMcid);
                     DocValue.Mcr mcrLabel =

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/UserIssueFormatter.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/UserIssueFormatter.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/VerbosityLevel.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/VerbosityLevel.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/cli/PdfAutoA11yCLI.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/cli/PdfAutoA11yCLI.java
@@ -118,7 +118,7 @@ public class PdfAutoA11yCLI {
             return;
         }
         if (config.dumpTreeSimple() || config.dumpTreeDetailed()) {
-            dumpTree(config);
+            printTreeDiagram(config);
             return;
         }
         if (config.listDestinations()) {
@@ -277,7 +277,7 @@ public class PdfAutoA11yCLI {
         }
     }
 
-    /** Applies /T scribbles from an annotated dump-tree text file to the input PDF. */
+    /** Applies /T scribbles from an annotated tree diagram file to the input PDF. */
     private static void annotateTree(CLIConfig config) {
         try {
             PdfCustodian custodian = new PdfCustodian(config.inputPath(), config.password());
@@ -301,8 +301,8 @@ public class PdfAutoA11yCLI {
         }
     }
 
-    /** Prints the structure tree to the console based on the CLI config. */
-    private static void dumpTree(CLIConfig config) {
+    /** Prints the structure tree diagram to the console based on the CLI config. */
+    private static void printTreeDiagram(CLIConfig config) {
         try {
             PdfCustodian custodian = new PdfCustodian(config.inputPath(), config.password());
             try (PdfDocument pdfDoc = custodian.openForReading()) {
@@ -560,8 +560,8 @@ public class PdfAutoA11yCLI {
                 + "  --dump-tree       Print the structure tree (with MCRs and annotations) and exit\n"
                 + "  --dump-roles      Print the structure tree (roles only) and exit\n"
                 + "  --list-destinations  Print named destinations by target page, and exit\n"
-                + "  --annotate-tree <file>  Read scribbles from an edited --dump-tree output\n"
-                + "                          file and write them to matching elements' /T keys\n"
+                + "  --annotate-tree <file>  Read scribbles from an annotated tree diagram\n"
+                + "                          and write them to matching elements' /T keys\n"
                 + "                          in the output PDF (no checks or fixes run)\n"
                 + "  --create-sidecar  Create a template sidecar config file and exit\n"
                 + "  --sidecar <file>  Use this sidecar config instead of <basename>.autoa11y.yaml\n"

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/cli/PdfAutoA11yCLI.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/cli/PdfAutoA11yCLI.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/ui/gui/PdfAutoA11yGUI.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/ui/gui/PdfAutoA11yGUI.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/validation/Check.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/validation/Check.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/validation/DocumentCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/validation/DocumentCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/validation/PatternMatcher.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/validation/PatternMatcher.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/validation/StructTreeCheck.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/validation/StructTreeCheck.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/validation/StructTreeContext.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/validation/StructTreeContext.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/validation/StructTreeWalker.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/validation/StructTreeWalker.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/java/net/boyechko/pdf/autoa11y/validation/TagSchema.java
+++ b/src/main/java/net/boyechko/pdf/autoa11y/validation/TagSchema.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,5 +17,12 @@
        malformed PDFs; not actionable by the user -->
   <logger name="com.itextpdf.kernel.pdf.tagging" level="error" />
 
+  <!-- ParentTreeHandler.registerAllMcrs() logs one ERROR per orphaned MCR
+       when opening a PDF whose pages were deleted in Acrobat without tag
+       cleanup. We detect/report orphans ourselves via OrphanedContentCheck,
+       so suppress iText's per-MCR error to keep the box UI readable. This
+       is the only LOGGER.error() in ParentTreeHandler; fatal cases throw. -->
+  <logger name="com.itextpdf.kernel.pdf.tagging.ParentTreeHandler" level="off" />
+
   <root level="warn" />
 </configuration>

--- a/src/test/java/net/boyechko/pdf/autoa11y/GoalDrivenIntegrationTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/GoalDrivenIntegrationTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/PdfTestBase.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/PdfTestBase.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/BadlyMappedLigatureCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/BadlyMappedLigatureCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/EmptyLinkTagCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/EmptyLinkTagCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/FigureWithTextCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/FigureWithTextCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/ImageOnlyDocumentCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/ImageOnlyDocumentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/ListlikeParagraphsCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/ListlikeParagraphsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/MissingAltTextCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/MissingAltTextCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/MissingDocumentCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/MissingDocumentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/MissingPagePartsCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/MissingPagePartsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/MistaggedArtifactCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/MistaggedArtifactCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/OrphanedContentCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/OrphanedContentCheckTest.java
@@ -1,0 +1,138 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2026 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.checks;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.itextpdf.kernel.pdf.PdfDictionary;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfName;
+import com.itextpdf.kernel.pdf.PdfNumber;
+import com.itextpdf.kernel.pdf.PdfReader;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.kernel.pdf.tagging.PdfMcrNumber;
+import com.itextpdf.kernel.pdf.tagging.PdfObjRef;
+import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import com.itextpdf.kernel.pdf.tagging.PdfStructTreeRoot;
+import net.boyechko.pdf.autoa11y.PdfTestBase;
+import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.issue.IssueList;
+import org.junit.jupiter.api.Test;
+
+class OrphanedContentCheckTest extends PdfTestBase {
+
+    /*
+     * An MCR is "orphaned" when iText's PdfMcr.getPageIndirectReference() returns null.
+     * The iText impl only checks the MCR's own dict and its immediate parent struct
+     * elem for /Pg -- so attaching a bare-int MCR to a struct elem that has no /Pg
+     * synthesizes the same state Acrobat leaves behind when pages are deleted without
+     * cleaning up tags.
+     */
+
+    @Test
+    void noIssuesOnValidTree() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfReader(TAGGED_BASELINE_PDF.toString()))) {
+            IssueList issues = new OrphanedContentCheck().findIssues(new DocContext(doc));
+            assertEquals(0, issues.size());
+        }
+    }
+
+    @Test
+    void detectsOrphanedMcr() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem p = new PdfStructElem(doc, PdfName.P);
+            document.addKid(p);
+            PdfMcrNumber mcr = new PdfMcrNumber(new PdfNumber(0), p);
+            p.addKid(mcr);
+
+            assertNull(mcr.getPageIndirectReference(), "preconditions: MCR is orphaned");
+
+            IssueList issues = new OrphanedContentCheck().findIssues(new DocContext(doc));
+            assertEquals(1, issues.size());
+        }
+    }
+
+    @Test
+    void detectsOrphanedObjr() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem link = new PdfStructElem(doc, PdfName.Link);
+            document.addKid(link);
+
+            PdfDictionary objRefDict = new PdfDictionary();
+            objRefDict.put(PdfName.Type, PdfName.OBJR);
+            objRefDict.put(PdfName.Obj, new PdfDictionary());
+            PdfObjRef objRef = new PdfObjRef(objRefDict, link);
+            link.addKid(objRef);
+
+            assertNull(objRef.getPageIndirectReference(), "preconditions: OBJR is orphaned");
+
+            IssueList issues = new OrphanedContentCheck().findIssues(new DocContext(doc));
+            assertEquals(1, issues.size());
+        }
+    }
+
+    @Test
+    void doesNotFlagMcrWithValidPageRef() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            var page = doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem p = new PdfStructElem(doc, PdfName.P, page);
+            document.addKid(p);
+            p.addKid(new PdfMcrNumber(page, p));
+
+            IssueList issues = new OrphanedContentCheck().findIssues(new DocContext(doc));
+            assertEquals(0, issues.size());
+        }
+    }
+
+    @Test
+    void emitsOneIssuePerOrphan() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem p = new PdfStructElem(doc, PdfName.P);
+            document.addKid(p);
+            p.addKid(new PdfMcrNumber(new PdfNumber(0), p));
+            p.addKid(new PdfMcrNumber(new PdfNumber(1), p));
+            p.addKid(new PdfMcrNumber(new PdfNumber(2), p));
+
+            IssueList issues = new OrphanedContentCheck().findIssues(new DocContext(doc));
+            assertEquals(3, issues.size());
+        }
+    }
+}

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/ParagraphOfLinksCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/ParagraphOfLinksCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/PdfUaConformanceCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/PdfUaConformanceCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/StaleScribbleCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/StaleScribbleCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/StructTreeOrderCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/StructTreeOrderCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/checks/StructureTreeExistsCheckTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/checks/StructureTreeExistsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/core/NoOpProcessingListener.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/core/NoOpProcessingListener.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/core/ProcessingServiceTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/core/ProcessingServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/document/PdfCustodianTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/document/PdfCustodianTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/document/RoleMapTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/document/RoleMapTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/document/StructTreeTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/document/StructTreeTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/document/StructTreeTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/document/StructTreeTest.java
@@ -132,7 +132,7 @@ class StructTreeTest extends PdfTestBase {
     }
 
     @Test
-    void determinePageNumberFromPgEntry() throws Exception {
+    void pageOfFromPgEntry() throws Exception {
         try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
             doc.setTagged();
             PdfPage page = doc.addNewPage();
@@ -143,12 +143,12 @@ class StructTreeTest extends PdfTestBase {
             root.addKid(p);
 
             DocContext ctx = new DocContext(doc);
-            assertEquals(1, StructTree.determinePageNumber(ctx, p));
+            assertEquals(1, StructTree.pageOf(p, ctx));
         }
     }
 
     @Test
-    void determinePageNumberFromChildRecursion() throws Exception {
+    void pageOfFromChildRecursion() throws Exception {
         try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
             doc.setTagged();
             PdfPage page = doc.addNewPage();
@@ -163,12 +163,12 @@ class StructTreeTest extends PdfTestBase {
 
             DocContext ctx = new DocContext(doc);
             // Div has no /Pg, but its child P does
-            assertEquals(1, StructTree.determinePageNumber(ctx, div));
+            assertEquals(1, StructTree.pageOf(div, ctx));
         }
     }
 
     @Test
-    void determinePageNumberReturnsZeroWhenUnresolvable() throws Exception {
+    void pageOfReturnsZeroWhenUnresolvable() throws Exception {
         try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
             doc.setTagged();
             doc.addNewPage();
@@ -178,7 +178,7 @@ class StructTreeTest extends PdfTestBase {
             root.addKid(div);
 
             DocContext ctx = new DocContext(doc);
-            assertEquals(0, StructTree.determinePageNumber(ctx, div));
+            assertEquals(0, StructTree.pageOf(div, ctx));
         }
     }
 

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/MissingDocumentFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/MissingDocumentFixTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/MissingPagePartsFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/MissingPagePartsFixTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/MistaggedArtifactFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/MistaggedArtifactFixTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/MistaggedArtifactFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/MistaggedArtifactFixTest.java
@@ -71,10 +71,9 @@ class MistaggedArtifactFixTest extends PdfTestBase {
             DocContext ctx = new DocContext(pdfDoc);
             new MistaggedArtifactFix(linkElem).apply(ctx);
 
-            // Element remains in tree but MCRs are stripped; pipeline cleanup removes it
-            assertFalse(
+            assertTrue(
                     document.getKids() == null || document.getKids().isEmpty(),
-                    "Element stays in tree (EmptyElementFix cleans up later)");
+                    "Empty Link element should be pruned from the tree");
             assertTrue(
                     page.getAnnotations().isEmpty(), "Link annotation should be removed from page");
         }
@@ -92,10 +91,10 @@ class MistaggedArtifactFixTest extends PdfTestBase {
             DocContext ctx = new DocContext(pdfDoc);
             new MistaggedArtifactFix(p).apply(ctx);
 
-            // Element stays in tree; EmptyElementFix cleans up later
+            // pruneEmpty stops at direct children of StructTreeRoot
             assertFalse(
                     root.getKids() == null || root.getKids().isEmpty(),
-                    "Element stays in tree (EmptyElementFix cleans up later)");
+                    "Direct StructTreeRoot child is not pruned");
         }
     }
 

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/NeedlessNestingFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/NeedlessNestingFixTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/OrphanedContentFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/OrphanedContentFixTest.java
@@ -1,0 +1,161 @@
+/*
+ * PDF-Auto-A11y - Automated PDF Accessibility Remediation
+ * Copyright (C) 2026 Richard Boyechko
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.boyechko.pdf.autoa11y.fixes;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfName;
+import com.itextpdf.kernel.pdf.PdfNumber;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.kernel.pdf.tagging.IStructureNode;
+import com.itextpdf.kernel.pdf.tagging.PdfMcrNumber;
+import com.itextpdf.kernel.pdf.tagging.PdfStructElem;
+import com.itextpdf.kernel.pdf.tagging.PdfStructTreeRoot;
+import java.util.List;
+import net.boyechko.pdf.autoa11y.PdfTestBase;
+import net.boyechko.pdf.autoa11y.document.DocContext;
+import net.boyechko.pdf.autoa11y.document.StructTree;
+import org.junit.jupiter.api.Test;
+
+class OrphanedContentFixTest extends PdfTestBase {
+
+    @Test
+    void removesOrphanedMcrFromParent() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem p = new PdfStructElem(doc, PdfName.P);
+            document.addKid(p);
+            PdfMcrNumber orphan = new PdfMcrNumber(new PdfNumber(0), p);
+            p.addKid(orphan);
+            PdfMcrNumber sibling = new PdfMcrNumber(new PdfNumber(1), p);
+            p.addKid(sibling);
+
+            new OrphanedContentFix(p, orphan).apply(new DocContext(doc));
+
+            List<IStructureNode> kids = p.getKids();
+            assertEquals(1, kids.size(), "only the orphan should be removed");
+        }
+    }
+
+    @Test
+    void prunesParentThatBecomesEmpty() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem siblingP = new PdfStructElem(doc, PdfName.P);
+            document.addKid(siblingP);
+            PdfStructElem orphanP = new PdfStructElem(doc, PdfName.P);
+            document.addKid(orphanP);
+            PdfMcrNumber orphan = new PdfMcrNumber(new PdfNumber(0), orphanP);
+            orphanP.addKid(orphan);
+
+            new OrphanedContentFix(orphanP, orphan).apply(new DocContext(doc));
+
+            List<IStructureNode> documentKids = document.getKids();
+            assertEquals(1, documentKids.size(), "empty orphan P should be pruned from Document");
+            assertSame(
+                    siblingP.getPdfObject(), ((PdfStructElem) documentKids.get(0)).getPdfObject());
+        }
+    }
+
+    @Test
+    void cascadesPruneUpToButNotIncludingDocument() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem section = new PdfStructElem(doc, PdfName.Sect);
+            document.addKid(section);
+            PdfStructElem p = new PdfStructElem(doc, PdfName.P);
+            section.addKid(p);
+            PdfMcrNumber orphan = new PdfMcrNumber(new PdfNumber(0), p);
+            p.addKid(orphan);
+
+            new OrphanedContentFix(p, orphan).apply(new DocContext(doc));
+
+            List<IStructureNode> documentKids = document.getKids();
+            assertTrue(
+                    documentKids == null || documentKids.isEmpty(),
+                    "Section -> P -> orphan: empty chain should be pruned");
+            assertNotNull(
+                    StructTree.findDocument(root), "Document itself remains as child of root");
+        }
+    }
+
+    @Test
+    void leavesParentIntactWhenStillHasKids() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem p = new PdfStructElem(doc, PdfName.P);
+            document.addKid(p);
+            PdfStructElem h1 = new PdfStructElem(doc, PdfName.H1);
+            document.addKid(h1);
+            PdfMcrNumber orphan = new PdfMcrNumber(new PdfNumber(0), p);
+            p.addKid(orphan);
+
+            new OrphanedContentFix(p, orphan).apply(new DocContext(doc));
+
+            // p is now empty and should be pruned, but document keeps h1
+            List<IStructureNode> documentKids = document.getKids();
+            assertEquals(1, documentKids.size());
+            assertSame(h1.getPdfObject(), ((PdfStructElem) documentKids.get(0)).getPdfObject());
+        }
+    }
+
+    @Test
+    void idempotentWhenOrphanAlreadyRemoved() throws Exception {
+        try (PdfDocument doc = new PdfDocument(new PdfWriter(testOutputStream()))) {
+            doc.setTagged();
+            doc.addNewPage();
+
+            PdfStructTreeRoot root = doc.getStructTreeRoot();
+            PdfStructElem document = new PdfStructElem(doc, PdfName.Document);
+            root.addKid(document);
+            PdfStructElem p = new PdfStructElem(doc, PdfName.P);
+            document.addKid(p);
+            PdfMcrNumber orphan = new PdfMcrNumber(new PdfNumber(0), p);
+            p.addKid(orphan);
+            PdfMcrNumber keeper = new PdfMcrNumber(new PdfNumber(1), p);
+            p.addKid(keeper);
+
+            OrphanedContentFix fix = new OrphanedContentFix(p, orphan);
+            fix.apply(new DocContext(doc));
+            assertDoesNotThrow(() -> fix.apply(new DocContext(doc)));
+
+            assertEquals(1, p.getKids().size(), "keeper still present after second apply");
+        }
+    }
+}

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/ParagraphOfLinksFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/ParagraphOfLinksFixTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/UnmarkedLinkFixTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/UnmarkedLinkFixTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/fixes/WrapParagraphRunInListTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/fixes/WrapParagraphRunInListTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/issue/IssueListTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/issue/IssueListTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/ui/AccessibilityReportTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/ui/AccessibilityReportTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/ui/FormattedListenerTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/ui/FormattedListenerTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/ui/SidecarConfigTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/ui/SidecarConfigTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/test/java/net/boyechko/pdf/autoa11y/validation/StructTreeWalkerTest.java
+++ b/src/test/java/net/boyechko/pdf/autoa11y/validation/StructTreeWalkerTest.java
@@ -1,6 +1,6 @@
 /*
  * PDF-Auto-A11y - Automated PDF Accessibility Remediation
- * Copyright (C) 2025 Richard Boyechko
+ * Copyright (C) 2026 Richard Boyechko
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published


### PR DESCRIPTION
- **feat(TreeDiagram): Box drawing characters for detailed tree diagram**
- **style(TreeDiagram,CLI): Use "tree diagram" for --dump-tree output**
- **fix(MistaggedArtifactFix): Prune empty Link after removing annotation-only element**
- **fix(TreeDiagram): Guard against orphaned MCRs**
- **fix(StructTree): pageOf() avoids NPE from iText's getPageObject()**
- **refactor(StructTree): determinePageNumber -> pageOf; reorder params**
- **chore: Fix copyright date in files created in 2026**
- **feat(checks,fixes): Add OrphanedContentCheck and Fix**
- **fix(scripts): pdf-autoa11y recompiles on changes to logback.xml**
- **chore: iTextPDF sources available in .itext-sources/**
